### PR TITLE
Fix custom config path not being resolved

### DIFF
--- a/lib/helpers/config-helper.js
+++ b/lib/helpers/config-helper.js
@@ -6,6 +6,10 @@ var args    = require('yargs').argv
 
 module.exports = {
   getConfigFile: function() {
+    if (args.config) {
+      return path.resolve(process.cwd(), args.config)
+    }
+
     return path.resolve(process.cwd(), 'config', 'config.json')
   },
 
@@ -60,7 +64,7 @@ module.exports = {
         try {
           this.config = require(this.getConfigFile())
         } catch(e) {
-          throw new Error('Error reading "' + this.relativeConfigFile() + '".')
+          throw new Error('Error reading "' + this.relativeConfigFile() + '". Error: ' + e.message)
         }
       }
 


### PR DESCRIPTION
The config path will now be resolved relative to process.cwd().
