### PR TITLE
sequelize model:create

### DIFF
--- a/lib/assets/migrations/migration.coffee
+++ b/lib/assets/migrations/migration.coffee
@@ -1,0 +1,8 @@
+module.exports =
+  up: (migration, DataTypes, done) ->
+    # add altering commands here, calling 'done' when finished
+    done()
+
+  down: (migration, DataTypes, done) ->
+    # add reverting commands here, calling 'done' when finished
+    done()

--- a/lib/assets/migrations/migration.js
+++ b/lib/assets/migrations/migration.js
@@ -1,0 +1,10 @@
+module.exports = {
+  up: function(migration, DataTypes, done) {
+    // add altering commands here, calling 'done' when finished
+    done()
+  },
+  down: function(migration, DataTypes, done) {
+    // add reverting commands here, calling 'done' when finished
+    done()
+  }
+}

--- a/lib/assets/models/model.js
+++ b/lib/assets/models/model.js
@@ -1,0 +1,13 @@
+module.exports = function(sequelize, DataTypes) {
+  var __NAME__ = sequelize.define('__NAME__', {
+__ATTRIBUTES__
+  }, {
+    classMethods: {
+      associate: function(models) {
+         // associations can be defined here
+      }
+    }
+  })
+
+  return __NAME__
+}

--- a/lib/helpers/asset-helper.js
+++ b/lib/helpers/asset-helper.js
@@ -6,9 +6,20 @@ module.exports = {
     fs.copySync(path.resolve(__dirname, '..', 'assets', from), to)
   },
 
-  injectConfigFilePath: function(filePath, configPath) {
+  read: function(assetPath) {
+    return fs.readFileSync(path.resolve(__dirname, '..', 'assets', assetPath)).toString()
+  },
+
+  write: function(targetPath, content) {
+    fs.writeFileSync(targetPath, content)
+  },
+
+  inject: function(filePath, token, content) {
     var fileContent = fs.readFileSync(filePath).toString()
-    fs.writeFileSync(filePath, fileContent.replace('__CONFIG_FILE__', configPath)
-    )
+    fs.writeFileSync(filePath, fileContent.replace(token, content))
+  },
+
+  injectConfigFilePath: function(filePath, configPath) {
+    this.inject(filePath, '__CONFIG_FILE__', configPath)
   }
 }

--- a/lib/helpers/config-helper.js
+++ b/lib/helpers/config-helper.js
@@ -3,7 +3,7 @@ var args    = require('yargs').argv
   , fs      = require('fs')
   , helpers = require(__dirname)
   , url     = require("url")
-
+  , _       = require('lodash')
 
 module.exports = {
   getConfigFile: function() {
@@ -88,8 +88,23 @@ module.exports = {
     return this.config
   },
 
-  supportsCoffee: function() {
-    var config = this.readConfig()
+  supportsCoffee: function(options) {
+    var config = null
+
+    options = _.extend({
+      ignoreConfig: false
+    }, options || {})
+
+    try {
+      config = this.readConfig()
+    } catch (e) {
+      if (options.ignoreConfig) {
+        config = {}
+      } else {
+        throw e
+      }
+    }
+
     return args.coffee || config.coffee
   },
 

--- a/lib/helpers/migration-helper.js
+++ b/lib/helpers/migration-helper.js
@@ -1,0 +1,60 @@
+var helpers   = require(__dirname)
+  , _         = require('lodash')
+  , _s        = require('underscore.string')
+  , Sequelize = require('sequelize')
+  , sequelize = new Sequelize()
+
+module.exports = {
+  getTableName: function(modelName) {
+    return sequelize.define(modelName, {}).tableName
+  },
+
+  generateFileContent: function(args) {
+    var migrationContent = helpers.asset.read('migrations/migration.js').split("\n")
+      , tableName        = this.getTableName(args.name)
+      , attributes       = helpers.model.transformAttributes(args.attributes)
+
+    migrationContent = migrationContent.reduce(function(acc, line) {
+      if (_.includes(line, '//')) {
+        return acc
+      } else if (_.includes(line, 'done()')) {
+        return acc
+      } else if (_.includes(line, 'up:')) {
+        return acc.concat([
+          line,
+          "    migration",
+          "      .createTable('" + tableName + "', {",
+        ]).concat(
+          _.map(attributes, function(value, key) {
+            return ("        " + key + ": DataTypes." + value.toUpperCase())
+          })
+        ).concat([
+          "      })",
+          "      .complete(done)"
+        ])
+      } else if (_.includes(line, 'down:')) {
+        return acc.concat([
+          line,
+          "    migration",
+          "      .dropTable('" + tableName + "')",
+          "      .complete(done)"
+        ])
+      } else {
+        return acc.concat([line])
+      }
+    }, [])
+
+    return migrationContent.join("\n")
+  },
+
+  generateMigrationName: function(args) {
+    return _s.ltrim(_s.dasherize("create-" + args.name), '-')
+  },
+
+  generateFile: function(args) {
+    var migrationName = this.generateMigrationName(args)
+      , migrationPath = helpers.path.getMigrationPath(migrationName)
+
+    helpers.asset.write(migrationPath, this.generateFileContent(args))
+  }
+}

--- a/lib/helpers/model-helper.js
+++ b/lib/helpers/model-helper.js
@@ -1,0 +1,53 @@
+var helpers = require(__dirname)
+  , _       = require('lodash')
+  , clc     = require('cli-color')
+  , fs      = require('fs-extra')
+
+module.exports = {
+  notifyAboutExistingFile: function(file) {
+    helpers.view.error('The file ' + clc.blueBright(file) + ' already exists. Run "sequelize model:create --force" to overwrite it.')
+  },
+
+  transformAttributes: function(flag) {
+    /*
+      possible flag formats:
+      - first_name:string,last_name:string,bio:text
+      - "first_name:string last_name:string bio:text"
+      - "first_name:string, last_name:string, bio:text"
+    */
+
+    var set    = flag.replace(/,/g, ' ').split(/\s+/)
+      , result = {}
+
+    set.forEach(function(pair) {
+      var split = pair.split(':')
+      result[split[0]] = split[1]
+    })
+
+    return result
+  },
+
+  generateFileContent: function(args) {
+    var attributes      = this.transformAttributes(args.attributes)
+      , attributesArray = []
+      , modelContent    = helpers.asset.read('models/model.js')
+
+    _.each(attributes, function(value, key) {
+      attributesArray.push(key + ": DataTypes." + value.toUpperCase())
+    })
+
+    modelContent = modelContent.replace(/(__NAME__)/g, args.name)
+    modelContent = modelContent.replace("__ATTRIBUTES__", "    " + attributesArray.join(",\n    "))
+
+    return modelContent
+  },
+
+  generateFile: function(args) {
+    var modelPath = helpers.path.getModelPath(args.name)
+    helpers.asset.write(modelPath, this.generateFileContent(args))
+  },
+
+  modelFileExists: function(filePath) {
+    return fs.existsSync(filePath)
+  }
+}

--- a/lib/helpers/path-helper.js
+++ b/lib/helpers/path-helper.js
@@ -2,13 +2,32 @@ var helpers = require(__dirname)
   , args    = require('yargs').argv
   , path    = require('path')
   , fs      = require('fs')
+  , moment  = require('moment')
 
 module.exports = {
   getMigrationsPath: function() {
     return args.migrationsPath || path.resolve(process.cwd(), 'migrations')
   },
 
+  getMigrationFileName: function(migrationName, options) {
+    var migrationExtension = helpers.config.supportsCoffee(options) ? '.coffee' : '.js'
+      , fullMigrationName  = [
+          moment().format('YYYYMMDDHHmmss'),
+          !!migrationName ? migrationName : 'unnamed-migration'
+        ].join('-') + migrationExtension
+
+    return fullMigrationName
+  },
+
+  getMigrationPath: function(migrationName) {
+    return path.resolve(this.getMigrationsPath(), this.getMigrationFileName(migrationName))
+  },
+
   getModelsPath: function() {
     return args.modelsPath || path.resolve(process.cwd(), 'models')
+  },
+
+  getModelPath: function(modelName) {
+    return path.resolve(this.getModelsPath(), modelName.toLowerCase() + '.js')
   }
 }

--- a/lib/helpers/view-helper.js
+++ b/lib/helpers/view-helper.js
@@ -20,6 +20,7 @@ module.exports = {
   },
 
   log: console.log,
+  error: console.error,
 
   pad: function(s, smth) {
     var margin = smth

--- a/lib/tasks/init.js
+++ b/lib/tasks/init.js
@@ -51,7 +51,7 @@ module.exports = {
       'init:models'
     ],
 
-    task: function() {}
+    task: function() {}
   },
 
   "init:config": {

--- a/lib/tasks/migration.js
+++ b/lib/tasks/migration.js
@@ -5,39 +5,11 @@ var path    = require('path')
   , fs      = require('fs')
   , clc     = require('cli-color')
 
-var getJsSkeleton = function() {
-  return [
-    "module.exports = {",
-    "  up: function(migration, DataTypes, done) {",
-    "    // add altering commands here, calling 'done' when finished",
-    "    done()",
-    "  },",
-    "  down: function(migration, DataTypes, done) {",
-    "    // add reverting commands here, calling 'done' when finished",
-    "    done()",
-    "  }",
-    "}"
-  ].join('\n') + "\n"
-}
-
-var getCoffeeSkeleton = function() {
-  return [
-    "module.exports = ",
-    "  up: (migration, DataTypes, done) ->",
-    "    # add altering commands here, calling 'done' when finished",
-    "    done()",
-    "",
-    "  down: (migration, DataTypes, done) ->",
-    "    # add reverting commands here, calling 'done' when finished",
-    "    done()"
-  ].join('\n') + "\n"
-}
-
 var getSkeleton = function() {
   if (helpers.config.supportsCoffee()) {
-    return getCoffeeSkeleton()
+    return helpers.asset.read('migrations/migration.coffee')
   } else {
-    return getJsSkeleton()
+    return helpers.asset.read('migrations/migration.js')
   }
 }
 
@@ -64,17 +36,12 @@ module.exports = {
         process.exit(1)
       }
 
-      var migrationExtension = helpers.config.supportsCoffee() ? '.coffee' : '.js'
-        , migrationName      = [
-            moment().format('YYYYMMDDHHmmss'),
-            !!args.name ? args.name : 'unnamed-migration'
-          ].join('-') + migrationExtension
+      fs.writeFileSync(helpers.path.getMigrationPath(args.name), getSkeleton())
 
-      fs.writeFileSync(helpers.path.getMigrationsPath() + '/' + migrationName, getSkeleton())
-
-      console.log(
-        'New migration "' + migrationName + '" was added to "' +
-        path.relative(process.cwd(), helpers.path.getMigrationsPath()) + '/".'
+      helpers.view.log(
+        'New migration was created at',
+        clc.blueBright(helpers.path.getMigrationPath(args.name)),
+        '.'
       )
     }
   }

--- a/lib/tasks/model.js
+++ b/lib/tasks/model.js
@@ -1,0 +1,115 @@
+var path    = require('path')
+  , helpers = require(path.resolve(__dirname, '..', 'helpers'))
+  , args    = require('yargs').argv
+  , clc     = require('cli-color')
+  , fs      = require('fs-extra')
+  , _       = require('lodash')
+
+module.exports = {
+  "model:create": {
+    aliases: [ 'model:generate' ],
+
+    descriptions: {
+      short: 'Generates a model and its migration.',
+
+      long: (function() {
+        var migrationFileName = helpers.path.getMigrationFileName(
+          helpers.migration.generateMigrationName({ name: 'User' }),
+          { ignoreConfig: true }
+        )
+
+        var result = [
+          'This task generates a model file and its respective migration.',
+          'It is necessary to specify the name of the new model as well as',
+          'the model\'s attributes.',
+          '',
+          'The attributes can be specified as in the following (and semantically equal) examples:',
+          '',
+          'sequelize model:create --name User --attributes first_name:string,last_name:string,bio:text',
+          'sequelize model:create --name User --attributes "first_name:string last_name:string bio:text"',
+          'sequelize model:create --name User --attributes "first_name:string, last_name:string, bio:text"',
+          '',
+          'This command will generate a new migration and model definition:',
+          '',
+          '// the model file',
+          '// located under models/user.js'
+        ]
+
+        result = result.concat(
+          helpers.model.generateFileContent({
+            name: 'User',
+            attributes: 'first_name:string,last_name:string,bio:text'
+          }).split("\n")
+        )
+
+        result = result.concat([
+          '',
+          '// the migration file',
+          '// located under migrations/' + migrationFileName
+        ])
+
+        result = result.concat(
+          helpers.migration.generateFileContent({
+            name: 'User',
+            attributes: 'first_name:string,last_name:string,bio:text'
+          }).split("\n")
+        )
+
+        return result
+      })(),
+
+      options: {
+        '--name': 'The name of the new model.',
+        '--attributes': 'A list of attributes.'
+      }
+    },
+
+    preChecks: [
+      function ensureAttributesFlag() {
+        if (!args.attributes) {
+          helpers.view.error('Unspecified flag ' + clc.blueBright('"attributes"') + '. Check the manual for further details.')
+          process.exit(1)
+        }
+      },
+
+      function ensureNameFlag() {
+        if (!args.name) {
+          helpers.view.error('Unspecified flag ' + clc.blueBright('"name"') + '. Check the manual for further details.')
+          process.exit(1)
+        }
+      },
+
+      function ensureModelsFolder() {
+        if (!fs.existsSync(helpers.path.getModelsPath())) {
+          helpers.view.error("Unable to find models path (" + helpers.path.getModelsPath() + "). Did you run " + clc.blueBright("sequelize init") + "?")
+          process.exit(1)
+        }
+      },
+
+      function ensureMigrationsFolder() {
+        if (!fs.existsSync(helpers.path.getMigrationsPath())) {
+          helpers.view.error("Unable to find migrations path (" + helpers.path.getMigrationsPath() + "). Did you run " + clc.blueBright("sequelize init") + "?")
+          process.exit(1)
+        }
+      },
+
+      function checkModelFileExistence() {
+        var modelPath = helpers.path.getModelPath(args.name)
+
+        if (!args.force && helpers.model.modelFileExists(modelPath)) {
+          helpers.model.notifyAboutExistingFile(modelPath)
+          process.exit(1)
+        }
+      }
+    ],
+
+    task: function() {
+      this.preChecks.forEach(function(preCheck) {
+        preCheck()
+      })
+
+      helpers.model.generateFile(args)
+      helpers.migration.generateFile(args)
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lodash": "~2.4.1",
     "moment": "~2.6.0",
     "sequelize": "*",
+    "underscore.string": "^2.3.3",
     "yargs": "~1.2.1"
   },
   "devDependencies": {

--- a/test/model/create.test.js
+++ b/test/model/create.test.js
@@ -1,0 +1,172 @@
+var expect    = require('expect.js')
+  , Support   = require(__dirname + '/../support')
+  , cli       = "bin/sequelize"
+  , helpers   = require(__dirname + '/../support/helpers')
+  , gulp      = require('gulp')
+  , _         = require('lodash')
+  ;
+
+([
+  'model:create',
+  'model:generate',
+]).forEach(function(flag) {
+  describe(Support.getTestDialectTeaser(flag), function() {
+    var combineFlags = function(flags) {
+      var result = flag
+
+      _.each(flags || {}, function(value, key) {
+        result = result + " --" + key + " " + value
+      })
+
+      return result
+    }
+
+    var prepare = function(options, callback) {
+      gulp
+        .src(Support.resolveSupportPath('tmp'))
+        .pipe(helpers.clearDirectory())
+        .pipe(helpers.runCli('init'))
+        .pipe(helpers.runCli(combineFlags(options.flags || {}), options.cli || { pipeStdout: true }))
+        .pipe(helpers.teardown(callback))
+    }
+
+    describe('name', function() {
+      describe('when missing', function() {
+        it('exits with an error code', function(done) {
+          prepare({
+            flags: { attributes: 'first_name:string' },
+            cli: { exitCode: 1 }
+          }, done)
+        })
+
+        it('notifies the user about a missing name flag', function(done) {
+          prepare({
+            flags: { attributes: 'first_name:string' },
+            cli: { pipeStderr: true }
+          }, function(err, stdout) {
+            expect(stdout).to.match(/Unspecified flag.*name/)
+            done()
+          })
+        })
+      })
+    })
+
+    describe('attributes', function() {
+      describe('when missing', function() {
+        it('exits with an error code', function(done) {
+          prepare({
+            flags: { name: 'User' },
+            cli: { exitCode: 1 }
+          }, done)
+        })
+
+        it('notifies the user about a missing attributes flag', function(done) {
+          prepare({
+            flags: { name: 'User' },
+            cli: { pipeStderr: true }
+          }, function(err, stdout) {
+            expect(stdout).to.match(/Unspecified flag.*attributes/)
+            done()
+          })
+        })
+      })
+
+      ;([
+        'first_name:string,last_name:string,bio:text',
+        '"first_name:string last_name:string bio:text"',
+        '"first_name:string, last_name:string, bio:text"'
+      ]).forEach(function(attributes) {
+        describe("--attributes " + attributes, function() {
+          it('exits with exit code 0', function(done) {
+            prepare({
+              flags: { name: 'User', attributes: attributes },
+              cli: { exitCode: 0 }
+            }, done)
+          })
+
+          it('creates the model file', function(done) {
+            prepare({
+              flags: { name: 'User', attributes: attributes }
+            }, function() {
+              gulp
+                .src(Support.resolveSupportPath('tmp', 'models'))
+                .pipe(helpers.listFiles())
+                .pipe(helpers.ensureContent('user.js'))
+                .pipe(helpers.teardown(done))
+            })
+          })
+
+          it('generates the model attributes correctly', function(done) {
+            prepare({
+              flags: { name: 'User', attributes: attributes }
+            }, function(err, stdout) {
+              gulp
+                .src(Support.resolveSupportPath('tmp', 'models'))
+                .pipe(helpers.readFile('user.js'))
+                .pipe(helpers.ensureContent("sequelize.define('User'"))
+                .pipe(helpers.ensureContent("first_name: DataTypes.STRING"))
+                .pipe(helpers.ensureContent("last_name: DataTypes.STRING"))
+                .pipe(helpers.ensureContent("bio: DataTypes.TEXT"))
+                .pipe(helpers.teardown(done))
+            })
+          })
+
+          it('creates the migration file', function(done) {
+            prepare({
+              flags: { name: 'User', attributes: attributes }
+            }, function() {
+              gulp
+                .src(Support.resolveSupportPath('tmp', 'migrations'))
+                .pipe(helpers.listFiles())
+                .pipe(helpers.ensureContent(/\d+-create-user.js/))
+                .pipe(helpers.teardown(done))
+            })
+          })
+
+          it('generates the migration content correctly', function(done) {
+            prepare({
+              flags: { name: 'User', attributes: attributes }
+            }, function(err, stdout) {
+              gulp
+                .src(Support.resolveSupportPath('tmp', 'migrations'))
+                .pipe(helpers.readFile('*-create-user.js'))
+                .pipe(helpers.ensureContent("migration"))
+                .pipe(helpers.ensureContent(".createTable('Users', {"))
+                .pipe(helpers.ensureContent("first_name: DataTypes.STRING"))
+                .pipe(helpers.ensureContent("last_name: DataTypes.STRING"))
+                .pipe(helpers.ensureContent("bio: DataTypes.TEXT"))
+                .pipe(helpers.ensureContent("})"))
+                .pipe(helpers.ensureContent(".complete(done)"))
+                .pipe(helpers.ensureContent(".dropTable('Users')"))
+                .pipe(helpers.teardown(done))
+            })
+          })
+
+          describe('when called twice', function() {
+            beforeEach(function(done) {
+              this.flags = { name: 'User', attributes: attributes }
+              prepare({ flags: this.flags }, done)
+            })
+
+            it('exits with an error code', function(done) {
+              gulp
+                .src(Support.resolveSupportPath('tmp'))
+                .pipe(helpers.runCli(combineFlags(this.flags), { exitCode: 1 }))
+                .pipe(helpers.teardown(done))
+            })
+
+            it('notifies the user about the possibility of --flags', function(done) {
+              gulp
+                .src(Support.resolveSupportPath('tmp'))
+                .pipe(helpers.runCli(combineFlags(this.flags), { pipeStderr: true }))
+                .pipe(helpers.teardown(function(err, stderr) {
+                  expect(stderr).to.contain("already exists")
+                  done()
+                }))
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -39,17 +39,26 @@ module.exports = {
     options = options || {}
     return through.obj(function(file, encoding, callback) {
       var command = support.getCliCommand(file.path, args)
-      exec(command, { cwd: file.path }, function(err, stdout) {
-        var result = options.pipeStdout ? stdout : file
+
+      exec(command, { cwd: file.path }, function(err, stdout, stderr) {
+        var result = file
+
+        if (options.pipeStdout) {
+          result = stdout
+        } else if (options.pipeStderr) {
+          result = stderr
+        }
 
         if (options.exitCode) {
           try {
+            expect(err).to.be.ok()
             expect(err.code).to.equal(1)
             callback(null, result)
           } catch(e) {
             callback(e, result)
           }
         } else {
+          err = options.pipeStderr ? null : err
           callback(err, result)
         }
       })
@@ -69,6 +78,7 @@ module.exports = {
         fun(stdout)
         callback(null, stdout)
       } catch (e) {
+        console.log(e)
         callback(e, null)
       }
     })


### PR DESCRIPTION
# Description

Add `sequelize model:create` which generates a model and it corresponding migration file.

This task generates a model file and its respective migration.
    It is necessary to specify the name of the new model as well as
    the model's attributes.

The attributes can be specified as in the following (and semantically equal) examples:

```
    sequelize model:create --name User --attributes first_name:string,last_name:string,bio:text
    sequelize model:create --name User --attributes "first_name:string last_name:string bio:text"
    sequelize model:create --name User --attributes "first_name:string, last_name:string, bio:text"
```

This command will generate a new migration and model definition:

```
    // the model file
    // located under models/user.js
    module.exports = function(sequelize, DataTypes) {
      var User = sequelize.define('User', {
        first_name: DataTypes.STRING,
        last_name: DataTypes.STRING,
        bio: DataTypes.TEXT
      }, {
        classMethods: {
          associate: function(models) {
             // associations can be defined here
          }
        }
      })

      return User
    }
```

```
    // the migration file
    // located under migrations/20140622195935-create-user.js
    module.exports = {
      up: function(migration, DataTypes, done) {
        migration
          .createTable('Users', {
            first_name: DataTypes.STRING
            last_name: DataTypes.STRING
            bio: DataTypes.TEXT
          })
          .complete(done)
      },
      down: function(migration, DataTypes, done) {
        migration
          .dropTable('Users')
          .complete(done)
      }
    }
```
# Discussion area:

I wonder if the API is OK or if there would be a better syntax for the attributes.
