### PR TITLE
Replace _.includes (removed from underscore.string) with _.include

### DIFF
--- a/lib/helpers/migration-helper.js
+++ b/lib/helpers/migration-helper.js
@@ -15,11 +15,11 @@ module.exports = {
       , attributes       = helpers.model.transformAttributes(args.attributes)
 
     migrationContent = migrationContent.reduce(function(acc, line) {
-      if (_.includes(line, '//')) {
+      if (_.include(line, '//')) {
         return acc
-      } else if (_.includes(line, 'done()')) {
+      } else if (_.include(line, 'done()')) {
         return acc
-      } else if (_.includes(line, 'up:')) {
+      } else if (_.include(line, 'up:')) {
         return acc.concat([
           line,
           "    migration",
@@ -32,7 +32,7 @@ module.exports = {
           "      })",
           "      .complete(done)"
         ])
-      } else if (_.includes(line, 'down:')) {
+      } else if (_.include(line, 'down:')) {
         return acc.concat([
           line,
           "    migration",


### PR DESCRIPTION
I don't know when, but this method was removed from `underscore.string`.

```
$ node_modules/.bin/sequelize init
```

```
Sequelize [CLI: v0.2.0, ORM: v2.0.0-dev12]

/Users/<...>/node_modules/sequelize-cli/lib/helpers/migration-helper.js:18
      if (_.includes(line, '//')) {
            ^
TypeError: Object function lodash(value) {
...
    } has no method 'includes'
    at /Users/<...>/node_modules/sequelize-cli/lib/helpers/migration-helper.js:18:13

```

Please, update npm ASAP.
It's deployment time.

Thanks=)
