### PR TITLE
Fix issue when mysql is not installed (closes #18)

### DIFF
--- a/lib/helpers/migration-helper.js
+++ b/lib/helpers/migration-helper.js
@@ -2,7 +2,14 @@ var helpers   = require(__dirname)
   , _         = require('lodash')
   , _s        = require('underscore.string')
   , Sequelize = require('sequelize')
-  , sequelize = new Sequelize()
+  , config    = helpers.config.readConfig()
+
+var sequelize = new Sequelize(
+  config.database,
+  config.username,
+  config.password,
+  config
+)
 
 module.exports = {
   getTableName: function(modelName) {


### PR DESCRIPTION
This is a fix for #18 where users who aren't using MySQL are not able to run any commands in the CLI, as it crashes instantiating Sequelize without args, which defaults to MySQL.

Passing in the user configuration should also make Sequelize behave more as expected.
