### PR TITLE
Add the connector version to the teaser.

### DIFF
--- a/lib/helpers/config-helper.js
+++ b/lib/helpers/config-helper.js
@@ -60,8 +60,12 @@ module.exports = {
     fs.writeFileSync(this.getConfigFile(), this.getDefaultConfig());
   },
 
-  readConfig: function () {
+  readConfig: function (options) {
     var env = helpers.generic.getEnvironment();
+
+    options = _.extend({
+      logging: true
+    }, options || {});
 
     if (!this.config) {
       if (args.url) {
@@ -78,14 +82,20 @@ module.exports = {
         throw new Error("Config must be an object: " + this.relativeConfigFile());
       }
 
-      if (args.url) {
-        console.log("Parsed url " + args.url);
-      } else {
-        console.log("Loaded configuration file '" + this.relativeConfigFile() + "'.");
+
+      if (options.logging) {
+        if (args.url) {
+          console.log("Parsed url " + args.url);
+        } else {
+          console.log("Loaded configuration file '" + this.relativeConfigFile() + "'.");
+        }
       }
 
       if (this.config[env]) {
-        console.log("Using environment '" + env + "'.");
+        if (options.logging) {
+          console.log("Using environment '" + env + "'.");
+        }
+        
         this.config = this.config[env];
       }
     }

--- a/lib/helpers/version-helper.js
+++ b/lib/helpers/version-helper.js
@@ -2,6 +2,7 @@
 
 var path        = require("path");
 var packageJson = require(path.resolve(__dirname, "..", "..", "package.json"));
+var helpers     = require(__dirname);
 
 module.exports = {
   getCliVersion: function() {
@@ -12,11 +13,41 @@ module.exports = {
     return require("sequelize/package.json").version;
   },
 
+  getDialect: function () {
+    try {
+      return helpers.config.readConfig({ logging: false });
+    } catch (e) {
+      return null;
+    }
+  },
+
   getDialectVersion: function() {
+    var adapterName = this.getDialectName();
+
+    try {
+      if (adapterName) {
+        return require(
+          path.resolve(process.cwd(), "package.json")
+        ).dependencies[adapterName];
+      }
+    } catch (e) {
+    }
+
     return null;
   },
 
   getDialectName: function() {
-    return null;
+    var config = this.getDialect();
+
+    if (config) {
+      return {
+        "sqlite":   "sqlite3",
+        "postgres": "pg",
+        "mariadb":  "mariasql",
+        "mysql":    "mysql"
+      }[config.dialect];
+    } else {
+      return null;
+    }
   }
 };

--- a/lib/helpers/view-helper.js
+++ b/lib/helpers/view-helper.js
@@ -7,14 +7,14 @@ var _       = require("lodash");
 module.exports = {
   teaser: function() {
     var versions = [
-      "CLI: v" + helpers.version.getCliVersion(),
-      "ORM: v" + helpers.version.getOrmVersion()
+      "CLI: " + helpers.version.getCliVersion(),
+      "ORM: " + helpers.version.getOrmVersion()
     ];
 
     if (helpers.version.getDialectName() && helpers.version.getDialectVersion()) {
       versions.push(
-        helpers.version.getDialectVersion +
-        ": v" +
+        helpers.version.getDialectName() +
+        ": " +
         helpers.version.getDialectVersion()
       );
     }


### PR DESCRIPTION
Besides the already in place information about the CLI version and
the core version, this PR adds also the name of the connector and 
its version from the cwd’s package.json. The result looks like this:

```
bin/sequelize h

Sequelize [CLI: 0.2.6, ORM: 2.0.0-rc1, sqlite3: ^2.2.7]

Loaded configuration file 'config/config.json'.
Using environment 'development'.
[20:10:14] Using sequelizefile ~/Projects/sequelize/cli/lib/sequelizefile.js
[20:10:14] Starting 'help'...

Usage
  sequelize [task]

…
```

Previously:

```
Sequelize [CLI: v0.2.6, ORM: v2.0.0-rc1]
```

Fixes #27.
