### PR TITLE
Add Node.JS version to the teaser.

### DIFF
--- a/lib/helpers/version-helper.js
+++ b/lib/helpers/version-helper.js
@@ -49,5 +49,9 @@ module.exports = {
     } else {
       return null;
     }
+  },
+
+  getNodeVersion: function () {
+    return process.version.replace("v", "");
   }
 };

--- a/lib/helpers/view-helper.js
+++ b/lib/helpers/view-helper.js
@@ -7,8 +7,9 @@ var _       = require("lodash");
 module.exports = {
   teaser: function() {
     var versions = [
-      "CLI: " + helpers.version.getCliVersion(),
-      "ORM: " + helpers.version.getOrmVersion()
+      "Node: " + helpers.version.getNodeVersion(),
+      "CLI: "  + helpers.version.getCliVersion(),
+      "ORM: "  + helpers.version.getOrmVersion()
     ];
 
     if (helpers.version.getDialectName() && helpers.version.getDialectVersion()) {


### PR DESCRIPTION
This commit adds the version of node.js to the teaser line.

Previously:

```
Sequelize [CLI: v0.2.6, ORM: v2.0.0-rc1]
```

Afterwards:

```
Sequelize [Node: 0.10.32, CLI: v0.2.6, ORM: v2.0.0-rc1]
```

Fixes #26.
Note: Removing the v from the version string is intended as it 
is the new default after #45 got merged.
