### PR TITLE
Fix global installation of the CLI

### DIFF
--- a/lib/helpers/generic-helper.js
+++ b/lib/helpers/generic-helper.js
@@ -2,6 +2,7 @@
 
 var fs   = require("fs");
 var args = require("yargs").argv;
+var path = require("path");
 
 module.exports = {
   mkdirp: function (path, root) {
@@ -24,5 +25,20 @@ module.exports = {
 
   getEnvironment: function() {
     return args.env || process.env.NODE_ENV || "development";
+  },
+
+  getSequelize: function (file) {
+    file = file || "index";
+
+    var sequelizePath = path.resolve(
+      process.cwd(), "node_modules", "sequelize", file
+    );
+
+    try {
+      return require(sequelizePath);
+    } catch (e) {
+      console.error("Unable to find sequelize package in " + sequelizePath);
+      process.exit(1);
+    }
   }
 };

--- a/lib/helpers/migration-helper.js
+++ b/lib/helpers/migration-helper.js
@@ -3,7 +3,7 @@
 var helpers   = require(__dirname);
 var _         = require("lodash");
 var _s        = require("underscore.string");
-var Sequelize = require("sequelize");
+var Sequelize = helpers.generic.getSequelize();
 
 module.exports = {
   getTableName: function(modelName) {

--- a/lib/helpers/version-helper.js
+++ b/lib/helpers/version-helper.js
@@ -10,7 +10,7 @@ module.exports = {
   },
 
   getOrmVersion: function() {
-    return require("sequelize/package.json").version;
+    return helpers.generic.getSequelize("package.json").version;
   },
 
   getDialect: function () {

--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -4,7 +4,7 @@ var path      = require("path");
 var helpers   = require(path.resolve(__dirname, "..", "helpers"));
 var args      = require("yargs").argv;
 var _         = require("lodash");
-var Sequelize = require("sequelize");
+var Sequelize = helpers.generic.getSequelize();
 
 var logMigrator = function(s) {
   if (s.indexOf("Executing") !== 0) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "gulp-help": "~0.1.6",
     "lodash": "^2.4.1",
     "moment": "~2.6.0",
-    "sequelize": "*",
     "underscore.string": "^2.3.3",
     "yargs": "~1.2.1"
   },
@@ -23,6 +22,7 @@
     "mocha": "~1.20.1",
     "mysql": "~2.1.1",
     "pg": "~3.0.3",
+    "sequelize": "^2.0.0-rc1",
     "sqlite3": "~2.2.3",
     "through2": "^0.5.1"
   },

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -44,12 +44,28 @@ module.exports = {
     });
   },
 
+  symlinkSequelize: function () {
+    var tmpNodeModules = support.resolveSupportPath("tmp", "node_modules");
+    var prjNodeModules = path.resolve(__dirname, "..", "..", "node_modules");
+    var srcPath        = path.resolve(prjNodeModules, "sequelize");
+    var targetPath     = path.resolve(tmpNodeModules, "sequelize");
+
+    fs.mkdirpSync(tmpNodeModules);
+
+    if (!fs.existsSync(targetPath)) {
+      fs.symlinkSync(srcPath, targetPath);
+    }
+  },
+
   runCli: function(args, options) {
     options = options || {};
+
+    var self = this;
 
     return through.obj(function(file, encoding, callback) {
       var command = support.getCliCommand(file.path, args);
 
+      self.symlinkSequelize();
       exec(command, { cwd: file.path }, function(err, stdout, stderr) {
         var result = file;
 

--- a/test/support/index.js
+++ b/test/support/index.js
@@ -2,7 +2,8 @@
 
 var fs        = require("fs");
 var path      = require("path");
-var Sequelize = require("sequelize");
+var helpers   = require(__dirname + "/../../lib/helpers");
+var Sequelize = helpers.generic.getSequelize();
 var _         = Sequelize.Utils._;
 var DataTypes = Sequelize;
 var Config    = require(__dirname + "/config/config");


### PR DESCRIPTION
This commit 
- removes Sequelize as dependency (and keeps it as dev dependency)
- uses the installed Sequelize package that is in process.cwd()
- fixes #32
