### PR TITLE
Add default attributes to migrations

### DIFF
--- a/lib/helpers/migration-helper.js
+++ b/lib/helpers/migration-helper.js
@@ -15,6 +15,12 @@ module.exports = {
     var tableName        = this.getTableName(args.name);
     var attributes       = helpers.model.transformAttributes(args.attributes);
 
+    attributes = _.extend({
+      id: "integer",
+      createdAt: "date",
+      updatedAt: "date"
+    }, attributes);
+
     migrationContent = migrationContent.reduce(function(acc, line) {
       if (_.include(line, "//")) {
         return acc;
@@ -24,21 +30,21 @@ module.exports = {
         return acc.concat([
           line,
           "    migration",
-          "      .createTable('" + tableName + "', {"
+          "      .createTable(\"" + tableName + "\", {"
         ]).concat(
           _.map(attributes, function(value, key) {
             return ("        " + key + ": DataTypes." + value.toUpperCase());
           }).join(",\n")
         ).concat([
           "      })",
-          "      .complete(done)"
+          "      .done(done);"
         ]);
       } else if (_.include(line, "down:")) {
         return acc.concat([
           line,
           "    migration",
-          "      .dropTable('" + tableName + "')",
-          "      .complete(done)"
+          "      .dropTable(\"" + tableName + "\")",
+          "      .done(done);"
         ]);
       } else {
         return acc.concat([line]);

--- a/test/model/create.test.js
+++ b/test/model/create.test.js
@@ -136,13 +136,16 @@ var _         = require("lodash");
                 .src(Support.resolveSupportPath("tmp", "migrations"))
                 .pipe(helpers.readFile("*-create-user.js"))
                 .pipe(helpers.ensureContent("migration"))
-                .pipe(helpers.ensureContent(".createTable('Users', {"))
+                .pipe(helpers.ensureContent(".createTable(\"Users\", {"))
                 .pipe(helpers.ensureContent("first_name: DataTypes.STRING"))
                 .pipe(helpers.ensureContent("last_name: DataTypes.STRING"))
                 .pipe(helpers.ensureContent("bio: DataTypes.TEXT"))
+                .pipe(helpers.ensureContent("id: DataTypes.INTEGER"))
+                .pipe(helpers.ensureContent("createdAt: DataTypes.DATE"))
+                .pipe(helpers.ensureContent("updatedAt: DataTypes.DATE"))
                 .pipe(helpers.ensureContent("})"))
-                .pipe(helpers.ensureContent(".complete(done)"))
-                .pipe(helpers.ensureContent(".dropTable('Users')"))
+                .pipe(helpers.ensureContent(".done(done)"))
+                .pipe(helpers.ensureContent(".dropTable(\"Users\")"))
                 .pipe(helpers.teardown(done));
             });
           });


### PR DESCRIPTION
This commit
- adds the default attributes to the generated migrations
- fixes jshint compatibility of the generated migrations
- change the `.complete` handler to `.done`
- fixes #33
