### PR TITLE
Use resolve and findup-sync to resolve modules relative to the cwd.

### DIFF
--- a/lib/helpers/generic-helper.js
+++ b/lib/helpers/generic-helper.js
@@ -3,6 +3,7 @@
 var fs   = require("fs");
 var args = require("yargs").argv;
 var path = require("path");
+var resolve = require("resolve").sync;
 
 module.exports = {
   mkdirp: function (path, root) {
@@ -28,17 +29,18 @@ module.exports = {
   },
 
   getSequelize: function (file) {
-    file = file || "index";
-
-    var sequelizePath = path.resolve(
-      process.cwd(), "node_modules", "sequelize", file
-    );
+    var sequelizePath;
 
     try {
-      return require(sequelizePath);
+      sequelizePath = resolve(
+        file ? path.join("sequelize", file) : "sequelize",
+        { basedir: process.cwd() }
+      );
     } catch (e) {
-      console.error("Unable to find sequelize package in " + sequelizePath);
+      console.error("Unable to resolve sequelize package in " + process.cwd());
       process.exit(1);
     }
+
+    return require(sequelizePath);
   }
 };

--- a/lib/helpers/version-helper.js
+++ b/lib/helpers/version-helper.js
@@ -3,6 +3,7 @@
 var path        = require("path");
 var packageJson = require(path.resolve(__dirname, "..", "..", "package.json"));
 var helpers     = require(__dirname);
+var findup      = require('findup-sync');
 
 module.exports = {
   getCliVersion: function() {
@@ -27,7 +28,7 @@ module.exports = {
     try {
       if (adapterName) {
         return require(
-          path.resolve(process.cwd(), "package.json")
+          findup("package.json")
         ).dependencies[adapterName];
       }
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "index.js",
   "dependencies": {
     "cli-color": "~0.3.2",
+    "findup-sync": "~0.1.3",
     "fs-extra": "^0.9.1",
     "gulp": "~3.6.2",
     "gulp-help": "~0.1.6",
     "lodash": "^2.4.1",
     "moment": "~2.6.0",
+    "resolve": "^1.0.0",
     "underscore.string": "^2.3.3",
     "yargs": "~1.2.1"
   },


### PR DESCRIPTION
- Using resolve to find sequelize allows sequelize-cli to work when sequelize is installed higher up the tree.
- Using findup to find package.json allows the same for checking the version of the dialect.
