### PR TITLE
Use node url module to parse db url

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var path      = require("path");
+var url       = require("url");
 var helpers   = require(path.resolve(__dirname, "..", "helpers"));
 var args      = require("yargs").argv;
 var _         = require("lodash");
@@ -30,17 +31,22 @@ var getSequelizeInstance = function() {
 
     if (key === "use_env_variable") {
       if (process.env[value]) {
-        var db_info = process.env[value].match(/([^:]+):\/\/([^:]+):([^@]+)@([^:]+):(\d+)\/(.+)/);
+        var dbUrl = url.parse(process.env[value]);
 
-        config.database = db_info[6];
-        config.username = db_info[2];
-        config.password = db_info[3];
+        var protocol = dbUrl.protocol.split(":")[0];
+
+        config.database = dbUrl.pathname.substring(1);
+        if (dbUrl.auth) {
+          var auth = dbUrl.auth.split(":");
+          config.username = auth[0];
+          config.password = auth[1];
+        }
 
         options = _.extend(options, {
-          host: db_info[4],
-          port: db_info[5],
-          dialect: db_info[1],
-          protocol: db_info[1]
+          host: dbUrl.hostname,
+          port: dbUrl.port,
+          dialect: protocol,
+          protocol: protocol
         });
       }
     }


### PR DESCRIPTION
Resolves #71 

IMPORTANT NOTE:

I tested this with some postgres URLs locally but there might be cases where either:

1. Some task (that I don't use) in sequelize is relying on some old behavior 
2. Someone else might use a database url that is not handled by this change

So: someone who knows the internals of sequelize and the cli a lot better than I do should review this.

I didn't see any existing tests for this so I didn't write any new ones.