### PR TITLE
Fixes issue where `tryToMigrateFromOldScheme` function was crashing mysteriously.

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -251,8 +251,12 @@ function tryToMigrateFromOldSchema () {
       var files      = fs.readdirSync(helpers.path.getMigrationsPath());
 
       return files.filter(function (file) {
-        var timestamp = file.match(/(\d+)-/)[1];
-        return timestamps.indexOf(timestamp) > -1;
+        var match = file.match(/(\d+)-?/);
+
+        if(match){
+          var timestamp = match[0].replace("-", "");
+          return timestamps.indexOf(timestamp) > -1;
+        }
       });
     })
     .then(function (files) {


### PR DESCRIPTION
If the file names in the migration did not contain a timestamp (either no timestamp or timestamp not terminated by a dash). Simply added a check on the result of filename.match, if it's null it's assumed not to be a migration. Otherwise all is apples.

Tested on my own projects, however I haven't run it against the unit tests as there doesn't seem to be tests for the eloquently named `tryToMigrateFromOldScheme` function.