### PR TITLE
Fix db:migrate:old_schema with sequelize >= 2.0.0

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -245,7 +245,7 @@ function tryToMigrateFromOldSchema () {
     return queryInterface.renameTable("SequelizeMeta", "SequelizeMetaBackup")
     .then(function () {
       var sql = queryInterface.QueryGenerator.selectQuery("SequelizeMetaBackup");
-      return sequelize.query(sql, null, { raw: true });
+      return sequelize.query(sql, null, { raw: true, type: 'SELECT' });
     })
     .then(function (result) {
       var timestamps = result.map(function (item) { return item.to; });


### PR DESCRIPTION
In Sequelize 2.0.0, `sequelize.query()` defaults to `type: 'RAW'` instead of `type: 'SELECT'`.