### PR TITLE
Add option for JSON storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,29 @@ like (that's is the one that `sequelize init` generates:
 }
 ```
 
+### Migration storage
+
+By default the CLI will create a table in your database called `SequelizeMeta` containing an entry
+for each executed migration.  Using `migrationStorage` in the configuration file you can have the
+CLI create a JSON file which will contain an array with all the executed migrations.  You can
+specify the path of the file using `migrationStoragePath` or the CLI will write to the file
+`sequelize-meta.json`.
+
+
+```json
+{
+  "development": {
+    "username": "root",
+    "password": null,
+    "database": "database_development",
+    "host": "127.0.0.1",
+    "dialect": "mysql",
+    "migrationStorage": "json",
+    "migrationStoragePath": "sequelize-meta.json"
+  }
+}
+```
+
 ### Schema migration
 
 Since v1.0.0 the CLI supports a new schema for saving the executed migrations. It will tell you about that

--- a/lib/helpers/umzug-helper.js
+++ b/lib/helpers/umzug-helper.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var path    = require("path");
+var _       = require("lodash");
+var helpers = require(__dirname);
+
+module.exports = {
+  getStorage: function () {
+    return helpers.config.readConfig().migrationStorage || "sequelize";
+  },
+
+  getStoragePath: function () {
+    return helpers.config.readConfig().migrationStoragePath ||
+      path.join(process.cwd(), "sequelize-meta.json");
+  },
+
+  getStorageOptions: function (extraOptions) {
+    var options = {};
+
+    if (this.getStorage() === "json") {
+      options.path = this.getStoragePath();
+    }
+
+    _.assign(options, extraOptions);
+
+    return options;
+  }
+};

--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -182,8 +182,8 @@ function getMigrator (callback) {
   if (helpers.config.configFileExists() || args.url) {
     var sequelize = getSequelizeInstance();
     var migrator  = new Umzug({
-      storage:        "sequelize",
-      storageOptions: { sequelize: sequelize },
+      storage:        helpers.umzug.getStorage(),
+      storageOptions: helpers.umzug.getStorageOptions({ sequelize: sequelize }),
       logging:        console.log,
       migrations:     {
         params:  [ sequelize.getQueryInterface(), Sequelize ],

--- a/test/db/migrate-json.test.js
+++ b/test/db/migrate-json.test.js
@@ -1,0 +1,123 @@
+"use strict";
+
+var expect    = require("expect.js");
+var Support   = require(__dirname + "/../support");
+var helpers   = require(__dirname + "/../support/helpers");
+var gulp      = require("gulp");
+var fs        = require("fs");
+var _         = require("lodash");
+
+([
+  "db:migrate",
+  "db:migrate --migrations-path migrations",
+  "--migrations-path migrations db:migrate",
+  "db:migrate --migrations-path ./migrations",
+  "db:migrate --migrations-path ./migrations/",
+  "db:migrate --coffee",
+  "db:migrate --config ../../support/tmp/config/config.json",
+  "db:migrate --config " + Support.resolveSupportPath("tmp", "config", "config.json"),
+  "db:migrate --config ../../support/tmp/config/config.js"
+]).forEach(function(flag) {
+  var prepare = function(callback, options) {
+    options = _.assign({ config: {} }, options || {});
+
+    var configPath    = "config/";
+    var migrationFile = options.migrationFile || "createPerson";
+    var config        = _.assign({
+      migrationStorage: "json"
+    }, helpers.getTestConfig(), options.config);
+    var configContent = JSON.stringify(config);
+
+    migrationFile = migrationFile + "."  + ((flag.indexOf("coffee") === -1) ? "js" : "coffee");
+
+    if (flag.match(/config\.js$/)) {
+      configPath    = configPath + "config.js";
+      configContent = "module.exports = " + configContent;
+    } else {
+      configPath = configPath + "config.json";
+    }
+
+    gulp
+      .src(Support.resolveSupportPath("tmp"))
+      .pipe(helpers.clearDirectory())
+      .pipe(helpers.runCli("init"))
+      .pipe(helpers.removeFile("config/config.json"))
+      .pipe(helpers.copyMigration(migrationFile))
+      .pipe(helpers.overwriteFile(configContent, configPath))
+      .pipe(helpers.runCli(flag, { pipeStdout: true }))
+      .pipe(helpers.teardown(callback));
+  };
+
+  describe(Support.getTestDialectTeaser(flag) + " (JSON)", function() {
+    describe("the migration storage file", function () {
+      it("should be written to the default location", function(done) {
+        var storageFile = Support.resolveSupportPath("tmp", "sequelize-meta.json");
+
+        prepare(function() {
+          expect(fs.statSync(storageFile).isFile()).to.be(true);
+          expect(fs.readFileSync(storageFile).toString())
+            .to.match(/^\[\n  "\d{14}-createPerson\.(js|coffee)"\n\]$/);
+          done();
+        });
+      });
+
+      it("should be written to the specified location", function(done) {
+        var storageFile = Support.resolveSupportPath("tmp", "custom-meta.json");
+
+        prepare(function() {
+          expect(fs.statSync(storageFile).isFile()).to.be(true);
+          expect(fs.readFileSync(storageFile).toString())
+            .to.match(/^\[\n  "\d{14}-createPerson\.(js|coffee)"\n\]$/);
+          done();
+        }, { config: { migrationStoragePath: storageFile } });
+      });
+    });
+
+    it("creates the respective table", function(done) {
+      var self = this;
+
+      prepare(function() {
+        helpers.readTables(self.sequelize, function(tables) {
+          expect(tables).to.have.length(1);
+          expect(tables).to.contain("Person");
+          done();
+        });
+      });
+    });
+
+    describe("the logging option", function() {
+      it("does not print sql queries by default", function(done) {
+        prepare(function(_, stdout) {
+          expect(stdout).to.not.contain("Executing");
+          done();
+        });
+      });
+
+      it("interprets a custom option", function(done) {
+        prepare(function(_, stdout) {
+          expect(stdout).to.contain("Executing");
+          done();
+        }, { config: { logging: true } });
+      });
+    });
+
+    describe("promise based migrations", function () {
+      it("correctly creates two tables", function (done) {
+        var self = this;
+
+        prepare(function () {
+          helpers.readTables(self.sequelize, function(tables) {
+            expect(tables.sort()).to.eql([
+              "Person",
+              "Task"
+            ]);
+            done();
+          });
+        }, {
+          migrationFile: "new/*createPerson",
+          config:        { promisifyMigrations: false }
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Please refer to Feature Request #101.

~~This commit introduces options `--storage` and `--storage-path` to tell Umzug to use JSON storage instead of MySQL table SequelizeMeta.~~

This commit introduces configuration options options `migrationStorage` and `migrationStoragePath` to tell Umzug to use JSON storage instead of MySQL table SequelizeMeta.