### PR TITLE
Fixed second try to resolve path to gulp

### DIFF
--- a/bin/sequelize
+++ b/bin/sequelize
@@ -12,7 +12,7 @@ var _       = require("lodash");
 var helpers = require(path.resolve(__dirname, "..", "lib", "helpers"));
 
 if (!fs.existsSync(gulp)) {
- gulp = path.resolve(process.cwd(), "node_modules", ".bin", "gulp");
+ gulp = path.resolve(process.cwd(), "node_modules", "gulp", "bin", "gulp.js");
 }
 
 if (!fs.existsSync(gulp)) {


### PR DESCRIPTION
The fallback to resolve gulp below current path did not work on windows because unix shell script was executed instead of gulp.js