### PR TITLE
addded db:migrate:undo:all to undo all migrations at once

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -60,6 +60,29 @@ module.exports = {
     }
   },
 
+  "db:migrate:undo:all": {
+    descriptions: {
+      "short": "Revert all migrations ran."
+    },
+
+    task: function() {
+      getMigrator(function(migrator) {
+        ensureCurrentMetaSchema(migrator).then(function () {
+          return migrator.executed();
+        }).then(function (migrations) {
+          if (migrations.length === 0) {
+            console.log("No executed migrations found.");
+            process.exit(0);
+          }
+        }).then(function () {
+          return migrator.down({to: 0});
+        }).then(function () {
+          process.exit(0);
+        });
+      });
+    }
+  },
+
   "db:migrate:old_schema": {
     descriptions: {
       "short": "Update legacy migration table",

--- a/test/db/migrate/all/all.test.js
+++ b/test/db/migrate/all/all.test.js
@@ -1,0 +1,68 @@
+  "use strict";
+
+var expect  = require("expect.js");
+var Support = require(__dirname + "/../../../support");
+var helpers = require(__dirname + "/../../../support/helpers");
+var gulp    = require("gulp");
+
+([
+  "db:migrate:undo:all"
+]).forEach(function(flag) {
+  var prepare = function(callback, _flag) {
+    _flag = _flag || flag;
+
+    gulp
+      .src(Support.resolveSupportPath("tmp"))
+      .pipe(helpers.clearDirectory())
+      .pipe(helpers.runCli("init"))
+      .pipe(helpers.copyMigration("createPerson.js"))
+      .pipe(helpers.copyMigration("renamePersonToUser.js"))
+      .pipe(helpers.overwriteFile(JSON.stringify(helpers.getTestConfig()), "config/config.json"))
+      .pipe(helpers.runCli(_flag, { pipeStdout: true }))
+      .pipe(helpers.teardown(callback));
+  };
+
+  describe(Support.getTestDialectTeaser(flag), function() {
+    it("creates a SequelizeMeta table", function(done) {
+      var self = this;
+
+      prepare(function() {
+        helpers.readTables(self.sequelize, function(tables) {
+          expect(tables).to.have.length(1);
+          expect(tables[0]).to.equal("SequelizeMeta");
+          done();
+        });
+      });
+    });
+
+    it("stops execution if no migrations have been done yet", function(done) {
+      prepare(function(err, output) {
+        expect(err).to.equal(null);
+        expect(output).to.contain("No executed migrations found.");
+        done();
+      }.bind(this));
+    });
+
+    it("is correctly undoing all migrations if they have been done already", function(done) {
+      var self = this;
+
+      prepare(function() {
+        helpers.readTables(self.sequelize, function(tables) {
+          expect(tables).to.have.length(2);
+          expect(tables).to.have.members("User","SequelizeMeta");
+
+          gulp
+            .src(Support.resolveSupportPath("tmp"))
+            .pipe(helpers.runCli(flag, { pipeStdout: true }))
+            .pipe(helpers.teardown(function() {
+              helpers.readTables(self.sequelize, function(tables) {
+                expect(tables).to.have.length(1);
+                expect(tables[0]).to.equal("SequelizeMeta");
+                done();
+              });
+            }));
+        });
+      }, "db:migrate");
+    });
+  });
+});

--- a/test/db/migrate/all/all.test.js
+++ b/test/db/migrate/all/all.test.js
@@ -49,7 +49,7 @@ var gulp    = require("gulp");
       prepare(function() {
         helpers.readTables(self.sequelize, function(tables) {
           expect(tables).to.have.length(2);
-          expect(tables).to.have.members("User","SequelizeMeta");
+          expect(tables).to.have.members(["User","SequelizeMeta"]);
 
           gulp
             .src(Support.resolveSupportPath("tmp"))

--- a/test/db/migrate/all/all.test.js
+++ b/test/db/migrate/all/all.test.js
@@ -49,7 +49,8 @@ var gulp    = require("gulp");
       prepare(function() {
         helpers.readTables(self.sequelize, function(tables) {
           expect(tables).to.have.length(2);
-          expect(tables).to.have.members(["User","SequelizeMeta"]);
+          expect(tables).to.contain("User");
+          expect(tables).to.contain("SequelizeMeta");
 
           gulp
             .src(Support.resolveSupportPath("tmp"))


### PR DESCRIPTION
Simple task to undo all migrations, instead of going one by one.