### PR TITLE
Ensure model is JavaScript file. Fixes #131.

### DIFF
--- a/lib/assets/models/index.js
+++ b/lib/assets/models/index.js
@@ -15,6 +15,7 @@ fs
     return (file.indexOf('.') !== 0) && (file !== basename);
   })
   .forEach(function(file) {
+    if (file.slice(-3) !== '.js') return;
     var model = sequelize['import'](path.join(__dirname, file));
     db[model.name] = model;
   });


### PR DESCRIPTION
This accounts for the situation when there are non-JavaScript files in
the `models/` folder. If one is detected, we don't try to load it.