### PR TITLE
Mask password when outputting parsed URL

### DIFF
--- a/lib/helpers/config-helper.js
+++ b/lib/helpers/config-helper.js
@@ -84,7 +84,7 @@ module.exports = {
 
       if (options.logging) {
         if (args.url) {
-          console.log('Parsed url ' + args.url);
+          console.log('Parsed url ' + args.url.replace(':' + this.config.password + '@', ':****@'));
         } else {
           console.log('Loaded configuration file "' + this.relativeConfigFile() + '".');
         }


### PR DESCRIPTION
Don't output password to CLI (for security).