### PR TITLE
Fix duplicate CLI args

### DIFF
--- a/bin/sequelize
+++ b/bin/sequelize
@@ -8,6 +8,7 @@ var path    = require('path');
 var gulp    = path.resolve(__dirname, '..', 'node_modules', 'gulp', 'bin', 'gulp.js');
 var args    = process.argv.slice(2);
 var yargs   = require('yargs');
+var argv    = yargs.argv;
 var _       = require('lodash');
 var helpers = require(path.resolve(__dirname, '..', 'lib', 'helpers'));
 
@@ -32,9 +33,14 @@ if ((args[0] === '-v') || (args[0] === '-V')) {
   }
 
   if (optionsPath) {
-    var options = require(optionsPath);
+    var options     = require(optionsPath);
+    var optionsKeys = Object.keys(options);
 
-    Object.keys(options).forEach(function (optionKey) {
+    optionsKeys = optionsKeys.filter(function (optionKey) {
+      return !argv[optionKey];
+    });
+
+    optionsKeys.forEach(function (optionKey) {
       var value = options[optionKey];
 
       if (optionKey.indexOf('--') !== 0) {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -28,4 +28,17 @@ describe(Support.getTestDialectTeaser('.sequelizerc'), function () {
       .pipe(helpers.ensureContent('db'))
       .pipe(helpers.teardown(done));
   });
+
+  it('prefers the CLI arguments over the sequelizerc file', function (done) {
+    var configPath = Support.resolveSupportPath('tmp', 'config', 'config.js');
+
+    gulp
+      .src(Support.resolveSupportPath('tmp'))
+      .pipe(helpers.clearDirectory())
+      .pipe(helpers.copyFile(optionsPath, '.sequelizerc'))
+      .pipe(helpers.runCli('init --config=' + configPath))
+      .pipe(helpers.listFiles())
+      .pipe(helpers.ensureContent('db'))
+      .pipe(helpers.teardown(done));
+  });
 });

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -57,8 +57,12 @@ module.exports = {
       var command = support.getCliCommand(file.path, args);
       var env     = _.extend({}, process.env, options.env);
 
+      logToFile(command);
+
       exec(command, { cwd: file.path, env: env }, function (err, stdout, stderr) {
         var result = file;
+
+        logToFile({err: err, stdout: stdout, stderr: stderr});
 
         if (stdout) {
           expect(stdout).to.not.contain('EventEmitter');
@@ -192,3 +196,12 @@ module.exports = {
       });
   }
 };
+
+function logToFile (thing) {
+  var text = (typeof thing === 'string') ? thing : JSON.stringify(thing);
+  var logPath = __dirname + '/../../logs';
+  var logFile = logPath + '/test.log';
+
+  fs.mkdirpSync(logPath);
+  fs.appendFileSync(logFile, '[' + new Date() + '] ' + text + '\n');
+}


### PR DESCRIPTION
Previously CLI calls would fail when an option was passed that was also
part of the config file or the options file.

Fixes https://github.com/sequelize/cli/issues/42