### PR TITLE
Change logging config to console.log function when set

### DIFF
--- a/lib/helpers/config-helper.js
+++ b/lib/helpers/config-helper.js
@@ -97,7 +97,7 @@ module.exports = {
 
         // The Sequelize library needs a function passed in to its logging option
         if (this.config.logging) {
-          this.config.logging = console.log
+          this.config.logging = console.log;
         }
         
         this.config = this.config[env];

--- a/lib/helpers/config-helper.js
+++ b/lib/helpers/config-helper.js
@@ -99,7 +99,7 @@ module.exports = {
         if (this.config.logging) {
           this.config.logging = console.log;
         }
-        
+
         this.config = this.config[env];
       }
     }

--- a/lib/helpers/config-helper.js
+++ b/lib/helpers/config-helper.js
@@ -95,6 +95,11 @@ module.exports = {
           console.log('Using environment "' + env + '".');
         }
 
+        // The Sequelize library needs a function passed in to its logging option
+        if (this.config.logging) {
+          this.config.logging = console.log
+        }
+        
         this.config = this.config[env];
       }
     }


### PR DESCRIPTION
I noticed a deprecation warning from the Sequelize library, resulting from setting the logging config in the Sequelise-cli option to true: 
https://github.com/sequelize/sequelize/commit/00399231d04ef617bdfb29826c4de3097f5bf553

As your code uses console.log elsewhere, this just compliments that (assuming similar semantics for the logging option as it is passed in)

Although, could so something more elaborate with converting a string to the function eg.
```javascript
        if (_.isString(this.config.logging)) {
          var funcPath = this.config.logging.split(".");
          var func = global;
          while (funcPath[0] && func) { func = func[funcPath[0]]; funcPath.shift(); }
          this.config.logging = (_.isFunction(func))? func : false;
        }
```
using the config option:
```json
...
   logging: "console.log"
...
```