### PR TITLE
adding schema option.

### DIFF
--- a/lib/assets/migrations/create-table.js
+++ b/lib/assets/migrations/create-table.js
@@ -22,14 +22,23 @@ module.exports = {
           type: Sequelize.DATE
         },
 
-        updatedAt: {
-          allowNull: false,
-          type: Sequelize.DATE
-        }
-      });
+                     updatedAt: {
+                       allowNull: false,
+                       type: Sequelize.DATE
+                     }
+                   }
+                   <% if (schema) { %>
+                   , {
+                      schema: '<%= schema %>'
+                   }
+                   <% } %>
+                   );
   },
 
   down: function (queryInterface, Sequelize) {
-    return queryInterface.dropTable('<%= tableName %>');
+    return queryInterface.dropTable('<%= tableName %>'
+                                    <% if (schema) { %>
+                                    , { schema: '<%= schema %>' }
+                                    <% } %>);
   }
 };

--- a/lib/assets/models/model.js
+++ b/lib/assets/models/model.js
@@ -12,6 +12,9 @@ module.exports = function(sequelize, DataTypes) {
         // associations can be defined here
       }
     }
+      <%  if (schema) { %>
+      , schema: '<%= schema %>'
+      <% } %>
   });
 
   return <%= name %>;

--- a/lib/helpers/migration-helper.js
+++ b/lib/helpers/migration-helper.js
@@ -12,7 +12,8 @@ module.exports = {
   generateTableCreationFileContent: function (args) {
     return helpers.template.render('migrations/create-table.js', {
       tableName:  this.getTableName(args.name),
-      attributes: helpers.model.transformAttributes(args.attributes)
+      attributes: helpers.model.transformAttributes(args.attributes),
+      schema: args.schema
     });
   },
 

--- a/lib/helpers/model-helper.js
+++ b/lib/helpers/model-helper.js
@@ -35,7 +35,8 @@ module.exports = {
   generateFileContent: function (args) {
     return helpers.template.render('models/model.js', {
       name:       args.name,
-      attributes: this.transformAttributes(args.attributes)
+      attributes: this.transformAttributes(args.attributes),
+      schema: args.schema
     });
   },
 


### PR DESCRIPTION
This is missing a bunch of documentation and, again tests.

allow user to specify 
`--schema schema_name` or to specify a schema entry in a sequelize options json file specifed by `--options-path`

```
{
   schema: 'my_schema',
   ...
}
```
