### PR TITLE
Add options for dialectOptions

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -276,6 +276,12 @@ function getSequelizeInstance () {
         });
       }
     }
+
+    if (key === 'dialectOptions') {
+      options = _.assign(options, {
+        dialectOptions: value
+      });
+    }
   });
 
   options = _.assign({ logging: logMigrator }, options);


### PR DESCRIPTION
There's a test for dialectOptions but when options are loaded from config file, dialectOptions get ignored. In order to create ssl connection to ssl enabled endpoints, we need to pass dialectOptions to mysql driver.