### PR TITLE
db.Model instead of db.model

### DIFF
--- a/lib/assets/models/index.js
+++ b/lib/assets/models/index.js
@@ -21,7 +21,8 @@ fs
   })
   .forEach(function(file) {
     var model = sequelize['import'](path.join(__dirname, file));
-    db[model.name] = model;
+    var modelName = model.name.charAt(0).toUpperCase() + model.name.slice(1)
+    db[modelName] = model;
   });
 
 Object.keys(db).forEach(function(modelName) {


### PR DESCRIPTION
When I define my model as such

```
  var Model = sequelize.define('model', attributes, {
    ...
```

It is more conventional and consistent to reference my model as `db.Model` and not `db.model` and still the naming conventions for foreign keys and so do not screw up.
