### PR TITLE
Fixed seeder to behave as a seeder should

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Upcoming
+### Changed
+- Default use of `seeder` memorizes nothing
+- Update umzug to 1.8.0
+
 ## v2.2.1 - 2015-11-24
 ### Fixed
 - Filtering of js files in models/index.js

--- a/README.md
+++ b/README.md
@@ -176,13 +176,24 @@ module.exports = {
 }
 ```
 
-### Migration storage
+### Storage
+
+There are three types of storage that you can use: `sequelize`, `json`, and `none`.
+
+- `sequelize` : stores migrations and seeds in a table on the sequelize database
+- `json` : stores migrations and seeds on a json file
+- `none` : does not store any migration/seed
+
+
+#### Migration
 
 By default the CLI will create a table in your database called `SequelizeMeta` containing an entry
-for each executed migration.  Using `migrationStorage` in the configuration file you can have the
-CLI create a JSON file which will contain an array with all the executed migrations.  You can
-specify the path of the file using `migrationStoragePath` or the CLI will write to the file
-`sequelize-meta.json`.
+for each executed migration. To change this behavior, there are three options you can add to the
+configuration file. Using `migrationStorage`, you can choose the type of storage to be used for
+migrations. If you choose `json`, you can specify the path of the file using `migrationStoragePath`
+or the CLI will write to the file `sequelize-meta.json`. If you want to keep the information in the
+database, using `sequelize`, but want to use a different table, you can change the table name using
+`migrationStorageTableName`.
 
 ```json
 {
@@ -192,23 +203,49 @@ specify the path of the file using `migrationStoragePath` or the CLI will write 
     "database": "database_development",
     "host": "127.0.0.1",
     "dialect": "mysql",
+
+    // Use a different storage type. Default: sequelize
     "migrationStorage": "json",
-    "migrationStoragePath": "sequelize-meta.json"
-  }
-}
-```
 
-If you want to keep the information in the database and like to configure the way it's stored,
-you can choose from the following configuration possibilites:
+    // Use a different file name. Default: sequelize-meta.json
+    "migrationStoragePath": "sequelizeMeta.json"
 
-```json
-{
-  "development": {
     // Use a different table name. Default: SequelizeMeta
     "migrationStorageTableName": "sequelize_meta"
   }
 }
 ```
+
+NOTE: The `none` storage is not recommended as a migration storage. If you decide to use it, be
+aware of the implications of having no record of what migrations did or didn't run.
+
+
+#### Seed
+
+By default the CLI will not save any seed that is executed. If you choose to change this behavior (!),
+you can use `seederStorage` in the configuration file to change the storage type. If you choose `json`,
+you can specify the path of the file using `seederStoragePath` or the CLI will write to the file
+`sequelize-data.json`. If you want to keep the information in the database, using `sequelize`, you can
+specify the table name using `seederStorageTableName`, or it will default to `SequelizeData`.
+
+```json
+{
+  "development": {
+    "username": "root",
+    "password": null,
+    "database": "database_development",
+    "host": "127.0.0.1",
+    "dialect": "mysql",
+    // Use a different storage. Default: none
+    "seederStorage": "json",
+    // Use a different file name. Default: sequelize-data.json
+    "seederStoragePath": "sequelizeData.json"
+    // Use a different table name. Default: SequelizeData
+    "seederStorageTableName": "sequelize_data"
+  }
+}
+```
+
 
 ### Dialect specific options
 

--- a/lib/helpers/umzug-helper.js
+++ b/lib/helpers/umzug-helper.js
@@ -4,6 +4,10 @@ var path    = require('path');
 var _       = require('lodash');
 var helpers = require(__dirname);
 
+var storage = {
+  migration: 'sequelize',
+  seeder: 'none'
+};
 var storageTableName = {
   migration: 'SequelizeMeta',
   seeder: 'SequelizeData'
@@ -19,7 +23,7 @@ module.exports = {
   },
 
   getStorage: function (type) {
-    return this.getStorageOption(type + 'Storage', 'sequelize');
+    return this.getStorageOption(type + 'Storage', storage[type]);
   },
 
   getStoragePath: function (type) {
@@ -37,7 +41,7 @@ module.exports = {
 
     if (this.getStorage(type) === 'json') {
       options.path = this.getStoragePath(type);
-    } else {
+    } else if (this.getStorage(type) === 'sequelize') {
       options.tableName = this.getTableName(type);
     }
 

--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -5,10 +5,11 @@ var fs        = require('fs');
 var path      = require('path');
 var url       = require('url');
 var helpers   = require(path.resolve(__dirname, '..', 'helpers'));
-var args      = require('yargs').argv;
+var args      = require('yargs').string('seed').argv;
 var _         = require('lodash');
 var Sequelize = helpers.generic.getSequelize();
 var Umzug     = require('umzug');
+var clc       = require('cli-color');
 
 module.exports = {
   'db:migrate': {
@@ -42,9 +43,42 @@ module.exports = {
 
   'db:seed': {
     descriptions: {
-      'short': 'Run seeders.',
+      'short': 'Run specified seeder.',
       'long': [
         'The command runs every existing seed file.'
+      ],
+      options: {
+        '--seed': 'List of seed files to run.'
+      }
+    },
+
+    preChecks: [
+      ensureSeeds
+    ],
+
+    task: function () {
+      this.preChecks.forEach(function (preCheck) {
+        preCheck();
+      });
+
+      getMigrator('seeder', function (migrator) {
+        migrator.up(args.seed)
+        .then(function () {
+          process.exit(0);
+        })
+        .catch(function (err) {
+          console.error('Seed file failed with error:', err.message);
+          process.exit(1);
+        });
+      });
+    }
+  },
+
+  'db:seed:all': {
+    descriptions: {
+      'short': 'Run every seeder.',
+      'long': [
+        'The command runs every existing seed file in alphabetical order.'
       ]
     },
 
@@ -53,13 +87,17 @@ module.exports = {
         migrator.pending()
         .then(function (seeders) {
           if (seeders.length === 0) {
-            console.log('No seeders were found.');
+            console.log('No seeders found.');
             process.exit(0);
           }
-        }).then(function () {
-          return migrator.up();
+
+          return migrator.up({migrations: _.chain(seeders).pluck('file').value()});
         }).then(function () {
           process.exit(0);
+        })
+        .catch(function (err) {
+          console.error('Seed file failed with error:', err.message);
+          process.exit(1);
         });
       });
     }
@@ -69,22 +107,26 @@ module.exports = {
     descriptions: {
       'short': 'Deletes data from the database.',
       'long': [
-        'The command unseeds every existing seed.'
+        'The command tries unseeding every existing seed.'
       ]
     },
 
     task: function () {
       getMigrator('seeder', function (migrator) {
-        migrator.executed()
+        migrator.pending()
         .then(function (seeders) {
           if (seeders.length === 0) {
-            console.log('No executed seeders found.');
+            console.log('No seeders found.');
             process.exit(0);
           }
-        }).then(function () {
-          return migrator.down({to: 0});
+
+          return migrator.down({migrations: _.chain(seeders).pluck('file').reverse().value()});
         }).then(function () {
           process.exit(0);
+        })
+        .catch(function (err) {
+          console.error('Seed file failed with error:', err.message);
+          process.exit(1);
         });
       });
     }
@@ -95,21 +137,29 @@ module.exports = {
       'short': 'Deletes data from the database.',
       'long': [
         'The command unseeds every existing seed.'
-      ]
+      ],
+      options: {
+        '--seed': 'List of seed files to unseed.'
+      }
     },
 
+    preChecks: [
+      ensureSeeds
+    ],
+
     task: function () {
+      this.preChecks.forEach(function (preCheck) {
+        preCheck();
+      });
+
       getMigrator('seeder', function (migrator) {
-        migrator.executed()
-        .then(function (seeders) {
-          if (seeders.length === 0) {
-            console.log('No executed seeders found.');
-            process.exit(0);
-          }
-        }).then(function () {
-          return migrator.down();
-        }).then(function () {
+        migrator.down({migrations: args.seed})
+        .then(function () {
           process.exit(0);
+        })
+        .catch(function (err) {
+          console.error('Seed file failed with error:', err.message);
+          process.exit(1);
         });
       });
     }
@@ -399,5 +449,28 @@ function tryToMigrateFromOldSchema () {
         );
       });
     });
+  });
+}
+
+/**
+ * ensureSeeds - checks that the `--seed` option exists
+ */
+
+function ensureSeeds () {
+  if ( !args.seed ) {
+    helpers.view.error(
+      'Unspecified flag ' +
+      clc.blueBright('"seed"') +
+      '. Check the manual for further details.'
+    );
+    process.exit(1);
+  }
+
+  if ( !_.isArray(args.seed) ) {
+    args.seed = [args.seed];
+  }
+
+  args.seed.forEach(function (file, ind) {
+    args.seed[ind] = path.basename(file);
   });
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lodash": "^3.0.1",
     "moment": "^2.11.0",
     "resolve": "^1.0.0",
-    "umzug": "^1.6.0",
+    "umzug": "^1.8.0",
     "yargs": "^3.30.0"
   },
   "devDependencies": {

--- a/test/db/seed.test.js
+++ b/test/db/seed.test.js
@@ -7,21 +7,22 @@ var gulp      = require('gulp');
 var _         = require('lodash');
 
 ([
-  'db:seed',
-  'db:seed --seeders-path seeders',
-  '--seeders-path seeders db:seed',
-  'db:seed --seeders-path ./seeders',
-  'db:seed --seeders-path ./seeders/',
-  'db:seed --coffee',
-  'db:seed --config ../../support/tmp/config/config.json',
-  'db:seed --config ' + Support.resolveSupportPath('tmp', 'config', 'config.json'),
-  'db:seed --config ../../support/tmp/config/config.js'
+  'db:seed --seed seedPerson.js',
+  'db:seed --seeders-path seeders --seed seedPerson.js',
+  '--seeders-path seeders db:seed --seed seedPerson.js',
+  'db:seed --seeders-path ./seeders --seed seedPerson.js',
+  'db:seed --seeders-path ./seeders/ --seed seedPerson.js',
+  'db:seed --coffee --seed seedPerson.coffee',
+  'db:seed --config ../../support/tmp/config/config.json --seed seedPerson.js',
+  'db:seed --seed seedPerson.js --config ' +
+    Support.resolveSupportPath('tmp', 'config', 'config.json'),
+  'db:seed --seed seedPerson.js --config ../../support/tmp/config/config.js'
 ]).forEach(function (flag) {
   var prepare = function (callback, options) {
     options = _.assign({ config: {} }, options || {});
 
     var configPath    = 'config/';
-    var seederFile    = options.seederFile || 'seedPerson';
+    var seederFile    = 'seedPerson';
     var config        = _.assign({}, helpers.getTestConfig(), options.config);
     var configContent = JSON.stringify(config);
     var migrationFile = 'createPerson.'  + ((flag.indexOf('coffee') === -1) ? 'js' : 'coffee');
@@ -44,8 +45,8 @@ var _         = require('lodash');
       .pipe(helpers.copySeeder(seederFile))
       .pipe(helpers.overwriteFile(configContent, configPath))
       .pipe(helpers.runCli('db:migrate' +
-        ((flag.indexOf('coffee') === -1 && flag.indexOf('config') === -1) ?
-          '' : flag.replace('db:seed', ''))))
+        ((flag.indexOf('coffee') === -1 && flag.indexOf('config') === -1) ? ''
+          : flag.replace('db:seed', ''))))
       .pipe(helpers.runCli(flag, { pipeStdout: true }))
       .pipe(helpers.teardown(callback));
   };
@@ -60,7 +61,7 @@ var _         = require('lodash');
           expect(tables).to.contain('SequelizeData');
           done();
         });
-      });
+      }, { config: { seederStorage: 'sequelize' } });
     });
 
     it('populates the respective table', function (done) {
@@ -101,7 +102,7 @@ var _         = require('lodash');
             done();
           });
         }, {
-          config: { seederStorageTableName: 'sequelize_data' }
+          config: { seederStorage: 'sequelize', seederStorageTableName: 'sequelize_data' }
         });
       });
     });

--- a/test/db/seed/undo/all.test.js
+++ b/test/db/seed/undo/all.test.js
@@ -8,41 +8,34 @@ var gulp    = require('gulp');
 ([
   'db:seed:undo:all'
 ]).forEach(function (flag) {
-  var prepare = function (callback, _flag) {
-    _flag = _flag || flag;
+  var prepare = function (callback, options) {
+    var _flag = options.flag || flag;
 
-    gulp
+    var pipeline = gulp
       .src(Support.resolveSupportPath('tmp'))
       .pipe(helpers.clearDirectory())
       .pipe(helpers.runCli('init'))
-      .pipe(helpers.copyMigration('createPerson.js'))
-      .pipe(helpers.copySeeder('seedPerson.js'))
-      .pipe(helpers.copySeeder('seedPerson2.js'))
-      .pipe(helpers.overwriteFile(JSON.stringify(helpers.getTestConfig()), 'config/config.json'))
+      .pipe(helpers.copyMigration('createPerson.js'));
+
+    if ( options.copySeeds ) {
+      pipeline.pipe(helpers.copySeeder('seedPerson.js'))
+      .pipe(helpers.copySeeder('seedPerson2.js'));
+    }
+
+    pipeline.pipe(helpers.overwriteFile(JSON.stringify(helpers.getTestConfig()),
+      'config/config.json'))
       .pipe(helpers.runCli('db:migrate'))
       .pipe(helpers.runCli(_flag, { pipeStdout: true }))
       .pipe(helpers.teardown(callback));
   };
 
   describe(Support.getTestDialectTeaser(flag), function () {
-    it('creates a SequelizeData table', function (done) {
-      var self = this;
-
-      prepare(function () {
-        helpers.readTables(self.sequelize, function (tables) {
-          expect(tables).to.have.length(3);
-          expect(tables[1]).to.equal('SequelizeData');
-          done();
-        });
-      });
-    });
-
-    it('stops execution if no seeders have been done yet', function (done) {
+    it('stops execution if no seeders have been found', function (done) {
       prepare(function (err, output) {
         expect(err).to.equal(null);
-        expect(output).to.contain('No executed seeders found.');
+        expect(output).to.contain('No seeders found.');
         done();
-      }.bind(this));
+      }.bind(this), {copySeeds: false});
     });
 
     it('is correctly undoing all seeders if they have been done already', function (done) {
@@ -64,7 +57,7 @@ var gulp    = require('gulp');
               });
             }));
         });
-      }, 'db:seed');
+      }, {flag: 'db:seed:all', copySeeds: true});
     });
   });
 });

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -164,9 +164,11 @@ module.exports = {
       var seederSource = support.resolveSupportPath('assets', 'seeders');
       var seederTarget = path.resolve(file.path, seedersFolder);
 
-      exec('cp ' + seederSource + '/*' + fileName + ' ' + seederTarget + '/', function (err) {
-        callback(err, file);
-      });
+      exec('cp ' + seederSource + '/*' + fileName + ' ' + seederTarget + '/' + fileName,
+        function (err) {
+          callback(err, file);
+        }
+      );
     });
   },
 


### PR DESCRIPTION
* it now defaults to no storage (does not store tasks run)
  * this can be changed with configurations
* db:seed and db:seed:undo now require an option '--seed' with the file to seed or unseed (multiple '--seed' options work)
* new db:seed:all command that runs all seeds available in the seeder directory
* db:seed:undo:all runs the down function for all seeds available in the seed directory