### PR TITLE
The command "sequelize db:seed:undo:all" strikes, because an improper…

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -113,7 +113,9 @@ module.exports = {
 
     task: function () {
       getMigrator('seeder', function (migrator) {
-        return migrator.executed()
+        return (helpers.umzug.getStorage('seeder') === 'none'
+                ? migrator.pending()
+                  : migrator.executed())
         .then(function (seeders) {
           if (seeders.length === 0) {
             console.log('No seeders found.');

--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -113,7 +113,7 @@ module.exports = {
 
     task: function () {
       getMigrator('seeder', function (migrator) {
-        return migrator.pending()
+        return migrator.executed()
         .then(function (seeders) {
           if (seeders.length === 0) {
             console.log('No seeders found.');


### PR DESCRIPTION
The command "sequelize db:seed:undo:all" strikes, because an improperly underlying Umzug API is invoked.
1. Umzug.prototype.pending() serves both db:migrate and db:seed.
2. Umzug.prototype.extecuted() serves both db:migrate:undo and db:seed:undo.

Mimicking the handle of the command "db:migrate:undo", supersede "migrator.pending()" with "migrator.executed()".
