### PR TITLE
Prevent ugly comments highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ or the CLI will write to the file `sequelize-meta.json`. If you want to keep the
 database, using `sequelize`, but want to use a different table, you can change the table name using
 `migrationStorageTableName`.
 
-```json
+```js
 {
   "development": {
     "username": "root",
@@ -228,7 +228,7 @@ you can specify the path of the file using `seederStoragePath` or the CLI will w
 `sequelize-data.json`. If you want to keep the information in the database, using `sequelize`, you can
 specify the table name using `seederStorageTableName`, or it will default to `SequelizeData`.
 
-```json
+```js
 {
   "development": {
     "username": "root",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,6 @@ var args        = require('yargs').argv;
 var gulp        = require('gulp');
 var jscs        = require('gulp-jscs');
 var jshint      = require('gulp-jshint');
-var mdBlock     = require('gulp-markdown-code-blocks');
 var mocha       = require('gulp-mocha');
 var path        = require('path');
 var runSequence = require('run-sequence');
@@ -18,7 +17,7 @@ gulp.task('test', function (done) {
 });
 
 gulp.task('lint', function (done) {
-  runSequence('lint-code', 'lint-readme', done);
+  runSequence('lint-code', done);
 });
 
 gulp.task('lint-code', function () {
@@ -36,12 +35,6 @@ gulp.task('lint-code', function () {
     .pipe(jshint())
     .pipe(jshint.reporter('default'))
     .pipe(jshint.reporter('fail'));
-});
-
-gulp.task('lint-readme', function () {
-  return gulp
-    .src('./README.md')
-    .pipe(mdBlock());
 });
 
 gulp.task('test-unit', function () {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "gulp-jscs": "^1.5.1",
     "gulp-jshint": "^1.10.0",
     "gulp-jshint-instafail": "^1.0.0",
-    "gulp-markdown-code-blocks": "^1.1.0",
     "gulp-mocha": "^2.0.0",
     "js2coffee": "^2.0.0",
     "jshint-stylish": "^1.0.0",


### PR DESCRIPTION
This changes the highlighting language of the examples with comments from JSON to JavaScript, because JSON does not allow comments and results in the following ugly highlighting artifacts:

![bildschirmfoto 2016-03-20 um 12 10 00](https://cloud.githubusercontent.com/assets/1935696/13904096/3bd88af0-ee95-11e5-9329-43646586226e.png)
