### PR TITLE
Coffeescript models skipped when loading from models dir

### DIFF
--- a/lib/assets/models/index.js
+++ b/lib/assets/models/index.js
@@ -17,7 +17,7 @@ if (config.use_env_variable) {
 fs
   .readdirSync(__dirname)
   .filter(function(file) {
-    return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+    return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js' || file.slice(-7) === '.coffee');
   })
   .forEach(function(file) {
     var model = sequelize['import'](path.join(__dirname, file));


### PR DESCRIPTION
The index.coffee code generated to load all the models in the models directory skipping CoffeeScript models
