### PR TITLE
Catch error for db:migrate:undo[:all]

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -183,6 +183,9 @@ module.exports = {
           return migrator.down();
         }).then(function () {
           process.exit(0);
+        }).catch(function (err) {
+          console.error(err);
+          process.exit(1);
         });
       });
     }
@@ -206,6 +209,9 @@ module.exports = {
           return migrator.down({to: 0});
         }).then(function () {
           process.exit(0);
+        }).catch(function (err) {
+          console.error(err);
+          process.exit(1);
         });
       });
     }


### PR DESCRIPTION
For now, the process exits correctly when there is an error.