### PR TITLE
Add underscored option to generated model when created with --underscored

### DIFF
--- a/lib/assets/models/model.js
+++ b/lib/assets/models/model.js
@@ -7,6 +7,7 @@ module.exports = function(sequelize, DataTypes) {
       <%= (Object.keys(attributes).length - 1) > index ? ',' : '' %>
     <% }) %>
   }, {
+    <%= underscored ? 'underscored: true,' : '' %>
     classMethods: {
       associate: function(models) {
         // associations can be defined here

--- a/lib/helpers/model-helper.js
+++ b/lib/helpers/model-helper.js
@@ -34,7 +34,8 @@ module.exports = {
   generateFileContent: function (args) {
     return helpers.template.render('models/model.js', {
       name:       args.name,
-      attributes: this.transformAttributes(args.attributes)
+      attributes: this.transformAttributes(args.attributes),
+      underscored: args.underscored
     });
   },
 

--- a/test/model/create.test.js
+++ b/test/model/create.test.js
@@ -185,6 +185,31 @@ var _         = require('lodash');
                     .pipe(helpers.teardown(done));
                 });
               });
+
+              it('generates the model content correctly', function (done) {
+                var flags = {
+                  name: 'User',
+                  attributes: attributes
+                };
+
+                var targetContent = attrUnd.underscored ?
+                  'underscored: true'
+                  : '{\n    classMethods';
+
+                if ( attrUnd.underscored ) {
+                  flags.underscored = attrUnd.underscored;
+                }
+
+                prepare({
+                  flags: flags
+                }, function () {
+                  gulp
+                    .src(Support.resolveSupportPath('tmp', 'models'))
+                    .pipe(helpers.readFile('user.js'))
+                    .pipe(helpers.ensureContent(targetContent))
+                    .pipe(helpers.teardown(done));
+                });
+              });
             });
           });
 


### PR DESCRIPTION
When creating a model with the `--underscored` flag, the option `underscored: true` was not added to the generated model file. 

Added a corresponding test case.

When the flag is not present, the model file is generated the same way it was before. 