### PR TITLE
Search for "executed" instead of "pending" migrations using db:seed:undo:all

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -113,7 +113,7 @@ module.exports = {
 
     task: function () {
       return getMigrator('seeder').then(function (migrator) {
-        return migrator.pending()
+        return migrator.executed()
         .then(function (seeders) {
           if (seeders.length === 0) {
             console.log('No seeders found.');


### PR DESCRIPTION
 When I started using a sequelize seeder storage, `db:seed:undo:all` did not worked anymore. After some investigations, I noticed that the command was looking for pending migrations instead of executed migrations. The similar behavior is correct for [`db:migration:undo:all`](https://github.com/sequelize/cli/blob/master/lib/tasks/db.js#L202).

~~I guess the problem does not occur when we do not use a storage because in this case there is no executed vs pending migrations.~~
The PR causes the unwanted behavior to occur when NOT using a storage. But does it really make sense to use this command without using a storage since there is no executed / pending migration in this case? Similarly when not using a storage, `db:seed:all` will execute seeds even if they already have been executed before, while using a storage, only pending seeds are executed.

If the desired behavior really is to consider all migrations as "pending" when not using a storage, I think this should be defined in Umzug's [none storage](https://github.com/sequelize/umzug/blob/master/lib/storages/none.js) and not in the sequelize CLI.

Any thoughts #?