### PR TITLE
Include error details when seeder throws an exception

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -67,7 +67,7 @@ module.exports = {
           process.exit(0);
         })
         .catch(function (err) {
-          console.error('Seed file failed with error:', err.message);
+          console.error('Seed file failed with error:', err);
           process.exit(1);
         });
       });
@@ -96,7 +96,7 @@ module.exports = {
           process.exit(0);
         })
         .catch(function (err) {
-          console.error('Seed file failed with error:', err.message);
+          console.error('Seed file failed with error:', err);
           process.exit(1);
         });
       });
@@ -125,7 +125,7 @@ module.exports = {
           process.exit(0);
         })
         .catch(function (err) {
-          console.error('Seed file failed with error:', err.message);
+          console.error('Seed file failed with error:', err);
           process.exit(1);
         });
       });
@@ -158,7 +158,7 @@ module.exports = {
           process.exit(0);
         })
         .catch(function (err) {
-          console.error('Seed file failed with error:', err.message);
+          console.error('Seed file failed with error:', err);
           process.exit(1);
         });
       });


### PR DESCRIPTION
Please don't drop important information like line number and stack trace on the ground when reporting errors.