### PR TITLE
include stack trace when printing error message if a seeder fails

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -67,7 +67,7 @@ module.exports = {
           process.exit(0);
         })
         .catch(function (err) {
-          console.error('Seed file failed with error:', err.message);
+          console.error('Seed file failed with error:', err.message, err.stack);
           process.exit(1);
         });
       });
@@ -96,7 +96,7 @@ module.exports = {
           process.exit(0);
         })
         .catch(function (err) {
-          console.error('Seed file failed with error:', err.message);
+          console.error('Seed file failed with error:', err.message, err.stack);
           process.exit(1);
         });
       });
@@ -125,7 +125,7 @@ module.exports = {
           process.exit(0);
         })
         .catch(function (err) {
-          console.error('Seed file failed with error:', err.message);
+          console.error('Seed file failed with error:', err.message, err.stack);
           process.exit(1);
         });
       });
@@ -158,7 +158,7 @@ module.exports = {
           process.exit(0);
         })
         .catch(function (err) {
-          console.error('Seed file failed with error:', err.message);
+          console.error('Seed file failed with error:', err.message, err.stack);
           process.exit(1);
         });
       });


### PR DESCRIPTION
I was building seeders for a new project and found that the error message printed did not include enough information (like which file caused the problem).  This PR enhances the error message printed in the .catch(function(e) { }) handlers so include the stack trace.  As an example, an exception running db:seed:undo now looks like the following, and I can know exactly where the error is.

== 20170110190423-admin-act: reverting =======
Seed file failed with error: Cannot read property 'getProfile' of null TypeError: Cannot read property 'getProfile' of null
    at Model.<anonymous> (/usr/src/app/server/db/seeders/20170110190423-admin-act.js:36:24)
    at Model.tryCatcher (/usr/src/app/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/usr/src/app/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (/usr/src/app/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromise0 (/usr/src/app/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/usr/src/app/node_modules/bluebird/js/release/promise.js:691:18)
    at Async._drainQueue (/usr/src/app/node_modules/bluebird/js/release/async.js:138:16)
    at Async._drainQueues (/usr/src/app/node_modules/bluebird/js/release/async.js:148:10)
    at Immediate.Async.drainQueues (/usr/src/app/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:649:20)
    at tryOnImmediate (timers.js:622:5)
    at processImmediate [as _immediateCallback] (timers.js:594:5)