### PR TITLE
Fix db:seed:undo:all

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -113,7 +113,8 @@ module.exports = {
 
     task: function () {
       return getMigrator('seeder').then(function (migrator) {
-        return migrator.pending()
+        return (helpers.umzug.getStorage('seeder') === 'none' ?
+          migrator.pending() : migrator.executed())
         .then(function (seeders) {
           if (seeders.length === 0) {
             console.log('No seeders found.');


### PR DESCRIPTION
I've recreated the pull request by @stuartZhang where the linting doesn't fail.
I've manually tested this on my own project using sequelize-cli version 2.5.1 with a postgres 9.6 database. 