### PR TITLE
Fix seed:undo:all issue

### DIFF
--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -113,7 +113,9 @@ module.exports = {
 
     task: function () {
       return getMigrator('seeder').then(function (migrator) {
-        return migrator.pending()
+        return (
+          helpers.umzug.getStorage('seeder') === 'none' ? migrator.pending() : migrator.executed()
+        )
         .then(function (seeders) {
           if (seeders.length === 0) {
             console.log('No seeders found.');


### PR DESCRIPTION
Check for `pending` seeds when seeder storage is 'none', otherwise check for `executed` seeds. Tests included

Closes https://github.com/sequelize/cli/pull/253
Closes https://github.com/sequelize/cli/pull/391
Closes https://github.com/sequelize/cli/pull/421

Fixes https://github.com/sequelize/cli/issues/252
Fixes https://github.com/sequelize/cli/issues/408
Fixes https://github.com/sequelize/cli/issues/403
Fixes https://github.com/sequelize/cli/issues/308