### PR TITLE
Improve documentation on ssl config for the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ module.exports = {
 }
 ```
 
+### Configuration for connecting over SSL
+
+Ensure ssl is specified in both `dialectOptions` and in the base config.
+
+```
+{
+    "production": {
+        "use_env_variable":"DB_CONNECTION_STRING",
+        "dialect":"postgres",
+        "ssl": true,
+        "dialectOptions": {
+            "ssl": true
+        }
+    }
+}
+
 ### Storage
 
 There are three types of storage that you can use: `sequelize`, `json`, and `none`.


### PR DESCRIPTION
Somewhat inspired by this issue: https://github.com/sequelize/cli/issues/154 where the last comment has 22 thumbs up at time of posting this issue. Their config is out of date but the activity there may be an indication that the documentation is lacking. Added an explicit section on SSL to clear that up