### PR TITLE
Improve sequelize options handling

### DIFF
--- a/lib/helpers/config-helper.js
+++ b/lib/helpers/config-helper.js
@@ -128,17 +128,22 @@ var api = {
       if (api.rawConfig[env]) {
         console.log('Using environment "' + env + '".');
 
-        // The Sequelize library needs a function passed in to its logging option
-        if (api.rawConfig.logging && !_.isFunction(api.rawConfig.logging)) {
-          api.rawConfig.logging = console.log;
-        }
-
         api.rawConfig = api.rawConfig[env];
+      }
+
+      // The Sequelize library needs a function passed in to its logging option
+      if (api.rawConfig.logging && !_.isFunction(api.rawConfig.logging)) {
+        api.rawConfig.logging = console.log;
       }
 
       // in case url is present - we overwrite the configuration
       if (api.rawConfig.url) {
         api.rawConfig = _.merge(api.rawConfig, api.parseDbUrl(api.rawConfig.url));
+      } else if (api.rawConfig.use_env_variable) {
+        api.rawConfig = _.merge(
+          api.rawConfig,
+          api.parseDbUrl(process.env[api.rawConfig.use_env_variable])
+        );
       }
 
       api.config = api.rawConfig;
@@ -176,10 +181,11 @@ var api = {
     try {
       var urlParts = url.parse(urlString);
       var result   = {
-        database: urlParts.path.replace(/^\//,  ''),
-        dialect:  urlParts.protocol,
+        database: urlParts.pathname.replace(/^\//,  ''),
         host:     urlParts.hostname,
-        port:     urlParts.port
+        port:     urlParts.port,
+        protocol: urlParts.protocol.replace(/:$/, ''),
+        ssl:      urlParts.query ? urlParts.query.indexOf('ssl=true') >= 0 : false
       };
 
       if (urlParts.auth) {
@@ -199,10 +205,10 @@ var api = {
     var config = api.urlStringToConfigHash(urlString);
 
     config = _.assign(config, {
-      dialect: config.dialect.replace(/:$/, '')
+      dialect: config.protocol
     });
 
-    if (config.dialect === 'sqlite') {
+    if (config.dialect === 'sqlite' && config.database.indexOf(':memory') !== 0) {
       config = _.assign(config, {
         storage: '/' + config.database
       });

--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -3,7 +3,6 @@
 var Bluebird  = require('bluebird');
 var fs        = require('fs');
 var path      = require('path');
-var url       = require('url');
 var helpers   = require(path.resolve(__dirname, '..', 'helpers'));
 var args      = require('yargs').string('seed').argv;
 var _         = require('lodash');
@@ -381,7 +380,6 @@ function ensureMetaTable (queryInterface, tableName) {
 
 function getSequelizeInstance () {
   var config  = null;
-  var options = {};
 
   try {
     config = helpers.config.readConfig();
@@ -390,48 +388,10 @@ function getSequelizeInstance () {
     process.exit(1);
   }
 
-  _.forEach(config, function (value, key) {
-    if (['database', 'username', 'password'].indexOf(key) === -1) {
-      options[key] = value;
-    }
-
-    if (key === 'use_env_variable' && process.env[value]) {
-      var dbUrl = url.parse(process.env[value]);
-      var protocol = dbUrl.protocol.split(':')[0];
-
-      config.database = dbUrl.pathname.substring(1);
-
-      if (protocol === 'sqlite') {
-        options.storage = dbUrl.pathname;
-      } else if (dbUrl.auth) {
-        var authParts = dbUrl.auth.split(':');
-
-        config.username = authParts[0];
-
-        if (authParts.length > 1) {
-          config.password = authParts.slice(1).join(':');
-        }
-      }
-
-      options = _.assign(options, {
-        host: dbUrl.hostname,
-        port: dbUrl.port,
-        dialect: protocol,
-        protocol: protocol
-      });
-    }
-
-    if (key === 'dialectOptions') {
-      options = _.assign(options, {
-        dialectOptions: value
-      });
-    }
-  });
-
-  options = _.assign({ logging: logMigrator }, options);
+  config = _.defaults(config, { logging: logMigrator });
 
   try {
-    return new Sequelize(config.database, config.username, config.password, options);
+    return new Sequelize(config);
   } catch (e) {
     console.warn(e);
     throw e;


### PR DESCRIPTION
We are already parsing config file options in `config-helper.js` and we should keep this all in the same place. This PR moves the `use_env_variable` to `config-helper.js` and removes all the extra logic from `tasks/db.js`.

Also fixed the database and ssl parameters, so an url string with `...?ssl=true` does not break anymore.