### PR TITLE
moving model.associate outside classMethods due to sequelize@4.0.0

### DIFF
--- a/lib/assets/models/model.js
+++ b/lib/assets/models/model.js
@@ -8,12 +8,11 @@ module.exports = function(sequelize, DataTypes) {
     <% }) %>
   }, {
     <%= underscored ? 'underscored: true,' : '' %>
-    classMethods: {
-      associate: function(models) {
-        // associations can be defined here
-      }
-    }
   });
+
+  <%= name %>.associate = function(models) {
+    // associations can be defined here
+  };
 
   return <%= name %>;
 };


### PR DESCRIPTION
I'm trying to figure out if sequelize-cli is supposed to match breaking changes introduced in sequelize@4.0.0. If yes, the model.associate method needs to be moved outside `classMethods` because `classMethods` was removed in sequelize@4.0.0.

Review my comment here: https://github.com/sequelize/cli/pull/468