### PR TITLE
Fix Relative Path on init for Windows Users

### DIFF
--- a/lib/helpers/init-helper.js
+++ b/lib/helpers/init-helper.js
@@ -73,7 +73,7 @@ module.exports = {
       helpers.asset.write(
         indexPath,
         helpers.template.render('models/index.js', {
-          configFile: '__dirname + \'/' + relativeConfigPath + '\''
+          configFile: '__dirname + \'/' + relativeConfigPath.replace(/\\/g, '/') + '\''
         }, {
           beautify: false
         })


### PR DESCRIPTION
Resolves #478 

The test in init.test.js already checks for forward-slashes, so no tests
need to be updated.