### PR TITLE
Adds the argument --es6 in the command migration:create and seed:create

### DIFF
--- a/lib/assets/migrations/skeleton-es6.js
+++ b/lib/assets/migrations/skeleton-es6.js
@@ -1,0 +1,21 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.createTable('users', { id: Sequelize.INTEGER });
+    */
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.dropTable('users');
+    */
+  }
+};

--- a/lib/assets/migrations/skeleton-es6.js
+++ b/lib/assets/migrations/skeleton-es6.js
@@ -17,5 +17,5 @@ module.exports = {
       Example:
       return queryInterface.dropTable('users');
     */
-  }
+  },
 };

--- a/lib/assets/seeders/skeleton-es6.js
+++ b/lib/assets/seeders/skeleton-es6.js
@@ -1,0 +1,24 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkInsert('Person', [{
+        name: 'John Doe',
+        isBetaMember: false
+      }], {});
+    */
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkDelete('Person', null, {});
+    */
+  },
+};

--- a/lib/tasks/migration.js
+++ b/lib/tasks/migration.js
@@ -33,7 +33,7 @@ module.exports = {
         process.exit(1);
       }
 
-      skeletonPath = args.es6 ?
+      skeletonPath = !helpers.config.supportsCoffee() && args.es6 ?
         'migrations/skeleton-es6.js' :
         'migrations/skeleton.js';
 

--- a/lib/tasks/migration.js
+++ b/lib/tasks/migration.js
@@ -13,14 +13,16 @@ module.exports = {
       options: {
         '--name': 'Defines the name of the migration. ' +
           clc.blueBright('Default: unnamed-migration'),
-        '--underscored': 'Use snake case for the timestamp\'s attribute names'
+        '--underscored': 'Use snake case for the timestamp\'s attribute names',
+        '--es6': 'Use es6 arrow function instead of traditional function',
       }
     },
 
     aliases: [ 'migration:generate' ],
 
     task: function () {
-      var config   = null;
+      var config        = null;
+      var skeletonPath  = null;
 
       helpers.init.createMigrationsFolder();
 
@@ -31,9 +33,13 @@ module.exports = {
         process.exit(1);
       }
 
+      skeletonPath = args.es6 ?
+        'migrations/skeleton-es6.js' :
+        'migrations/skeleton.js';
+
       fs.writeFileSync(
         helpers.path.getMigrationPath(args.name),
-        helpers.template.render('migrations/skeleton.js', {}, {
+        helpers.template.render(skeletonPath, {}, {
           beautify: false
         })
       );

--- a/lib/tasks/seed.js
+++ b/lib/tasks/seed.js
@@ -12,14 +12,16 @@ module.exports = {
       'short': 'Generates a new seed file.',
       options: {
         '--name': 'Defines the name of the seed. ' +
-          clc.blueBright('Default: unnamed-seed')
+          clc.blueBright('Default: unnamed-seed'),
+        '--es6': 'Use es6 arrow function instead of traditional function',
       }
     },
 
     aliases: [ 'seed:generate' ],
 
     task: function () {
-      var config   = null;
+      var config        = null;
+      var skeletonPath  = null;
 
       helpers.init.createSeedersFolder();
 
@@ -30,9 +32,13 @@ module.exports = {
         process.exit(1);
       }
 
+      skeletonPath = !helpers.config.supportsCoffee() && args.es6 ?
+        'seeders/skeleton-es6.js' :
+        'seeders/skeleton.js';
+
       fs.writeFileSync(
         helpers.path.getSeederPath(args.name),
-        helpers.template.render('seeders/skeleton.js', {}, {
+        helpers.template.render(skeletonPath, {}, {
           beautify: false
         })
       );

--- a/test/migration/create.test.js
+++ b/test/migration/create.test.js
@@ -13,6 +13,8 @@ var _         = require('lodash');
   'migration:generate --coffee',
   'migration:create --es6',
   'migration:generate --es6',
+  'migration:create --es6 --coffee',
+  'migration:generate --es6 --coffee',
 ]).forEach(function (flag) {
   describe(Support.getTestDialectTeaser(flag), function () {
     var migrationFile = 'foo.' + (_.includes(flag, '--coffee') ? 'coffee' : 'js');
@@ -26,28 +28,28 @@ var _         = require('lodash');
         .pipe(helpers.teardown(callback));
     };
 
-    it('creates a new file with the current timestamp', function (done) {
-      prepare(function () {
-        var date        = new Date();
-        var format      = function (i) {
-          return (parseInt(i, 10) < 10 ? '0' + i : i);
-        };
-        var sDate       = [
-          date.getFullYear(),
-          format(date.getMonth() + 1),
-          format(date.getDate()),
-          format(date.getHours()),
-          format(date.getMinutes())
-        ].join('');
-        var expectation = new RegExp(sDate + '..-' + migrationFile);
+    // it('creates a new file with the current timestamp', function (done) {
+    //   prepare(function () {
+    //     var date        = new Date();
+    //     var format      = function (i) {
+    //       return (parseInt(i, 10) < 10 ? '0' + i : i);
+    //     };
+    //     var sDate       = [
+    //       date.getFullYear(),
+    //       format(date.getMonth() + 1),
+    //       format(date.getDate()),
+    //       format(date.getHours()),
+    //       format(date.getMinutes())
+    //     ].join('');
+    //     var expectation = new RegExp(sDate + '..-' + migrationFile);
 
-        gulp
-          .src(Support.resolveSupportPath('tmp', 'migrations'))
-          .pipe(helpers.listFiles())
-          .pipe(helpers.ensureContent(expectation))
-          .pipe(helpers.teardown(done));
-      });
-    });
+    //     gulp
+    //       .src(Support.resolveSupportPath('tmp', 'migrations'))
+    //       .pipe(helpers.listFiles())
+    //       .pipe(helpers.ensureContent(expectation))
+    //       .pipe(helpers.teardown(done));
+    //   });
+    // });
 
     it('adds a skeleton with an up and a down method', function (done) {
       prepare(function () {

--- a/test/migration/create.test.js
+++ b/test/migration/create.test.js
@@ -28,28 +28,28 @@ var _         = require('lodash');
         .pipe(helpers.teardown(callback));
     };
 
-    // it('creates a new file with the current timestamp', function (done) {
-    //   prepare(function () {
-    //     var date        = new Date();
-    //     var format      = function (i) {
-    //       return (parseInt(i, 10) < 10 ? '0' + i : i);
-    //     };
-    //     var sDate       = [
-    //       date.getFullYear(),
-    //       format(date.getMonth() + 1),
-    //       format(date.getDate()),
-    //       format(date.getHours()),
-    //       format(date.getMinutes())
-    //     ].join('');
-    //     var expectation = new RegExp(sDate + '..-' + migrationFile);
+    it('creates a new file with the current timestamp', function (done) {
+      prepare(function () {
+        var date        = new Date();
+        var format      = function (i) {
+          return (parseInt(i, 10) < 10 ? '0' + i : i);
+        };
+        var sDate       = [
+          date.getFullYear(),
+          format(date.getMonth() + 1),
+          format(date.getDate()),
+          format(date.getHours()),
+          format(date.getMinutes())
+        ].join('');
+        var expectation = new RegExp(sDate + '..-' + migrationFile);
 
-    //     gulp
-    //       .src(Support.resolveSupportPath('tmp', 'migrations'))
-    //       .pipe(helpers.listFiles())
-    //       .pipe(helpers.ensureContent(expectation))
-    //       .pipe(helpers.teardown(done));
-    //   });
-    // });
+        gulp
+          .src(Support.resolveSupportPath('tmp', 'migrations'))
+          .pipe(helpers.listFiles())
+          .pipe(helpers.ensureContent(expectation))
+          .pipe(helpers.teardown(done));
+      });
+    });
 
     it('adds a skeleton with an up and a down method', function (done) {
       prepare(function () {

--- a/test/migration/create.test.js
+++ b/test/migration/create.test.js
@@ -10,7 +10,9 @@ var _         = require('lodash');
   'migration:create',
   'migration:generate',
   'migration:create --coffee',
-  'migration:generate --coffee'
+  'migration:generate --coffee',
+  'migration:create --es6',
+  'migration:generate --es6',
 ]).forEach(function (flag) {
   describe(Support.getTestDialectTeaser(flag), function () {
     var migrationFile = 'foo.' + (_.includes(flag, '--coffee') ? 'coffee' : 'js');
@@ -56,6 +58,9 @@ var _         = require('lodash');
             if (_.includes(flag, 'coffee')) {
               expect(stdout).to.contain('up: (queryInterface, Sequelize) ->');
               expect(stdout).to.contain('down: (queryInterface, Sequelize) ->');
+            } else if (_.includes(flag, 'es6')) {
+              expect(stdout).to.contain('up: (queryInterface, Sequelize) => {');
+              expect(stdout).to.contain('down: (queryInterface, Sequelize) => {');
             } else {
               expect(stdout).to.contain('up: function (queryInterface, Sequelize) {');
               expect(stdout).to.contain('down: function (queryInterface, Sequelize) {');

--- a/test/seed/create.test.js
+++ b/test/seed/create.test.js
@@ -10,7 +10,11 @@ var _         = require('lodash');
   'seed:create',
   'seed:generate',
   'seed:create --coffee',
-  'seed:generate --coffee'
+  'seed:generate --coffee',
+  'seed:create --es6',
+  'seed:generate --es6',
+  'seed:create --es6 --coffee',
+  'seed:generate --es6 --coffee',
 ]).forEach(function (flag) {
   describe(Support.getTestDialectTeaser(flag), function () {
     var seedFile = 'foo.' + (_.includes(flag, '--coffee') ? 'coffee' : 'js');
@@ -56,6 +60,9 @@ var _         = require('lodash');
             if (_.includes(flag, 'coffee')) {
               expect(stdout).to.contain('up: (queryInterface, Sequelize) ->');
               expect(stdout).to.contain('down: (queryInterface, Sequelize) ->');
+            } else if (_.includes(flag, 'es6')) {
+              expect(stdout).to.contain('up: (queryInterface, Sequelize) => {');
+              expect(stdout).to.contain('down: (queryInterface, Sequelize) => {');
             } else {
               expect(stdout).to.contain('up: function (queryInterface, Sequelize) {');
               expect(stdout).to.contain('down: function (queryInterface, Sequelize) {');


### PR DESCRIPTION
The purpose of the PR is to add the option `--es6` to the command `migration:create`.

When executing `migration:create --es6` it will use a skeleton in ES6 format with arrow functions.

This PR resolves issue #482, although it is not a breaking change required for major version. Maybe a future PR can change the default skeleton to be in ES6 format.

This PR may resolve issue #389 if it is a duplicate from #482.

OBS: When executing `migration:create --es6 --coffee`, the argument `--es6` will be ignored. The reason is that the js file would be converted to a coffee file. 'Would' is the correct word here because [js2coffee](https://www.npmjs.com/package/js2coffee) doesn't support ES6 yet (See [issue](https://github.com/js2coffee/js2coffee/issues/449))