### PR TITLE
Add warning when using with Sequelize v4.

### DIFF
--- a/lib/helpers/view-helper.js
+++ b/lib/helpers/view-helper.js
@@ -25,7 +25,11 @@ module.exports = {
     this.log();
 
     if (helpers.version.getOrmVersion().match(/^4./)) {
-      this.log(clc.yellow('WARNING: This version of Sequelize CLI is not fully compatible with Sequelize v4. https://github.com/sequelize/cli#sequelize-support'));
+      this.log(clc.yellow(
+        'WARNING: This version of Sequelize CLI is not ' +
+        'fully compatible with Sequelize v4. ' +
+        'https://github.com/sequelize/cli#sequelize-support'
+      ));
       this.log();
     }
   },

--- a/lib/helpers/view-helper.js
+++ b/lib/helpers/view-helper.js
@@ -23,6 +23,11 @@ module.exports = {
     this.log();
     this.log(clc.underline('Sequelize [' + versions.join(', ') + ']'));
     this.log();
+
+    if (helpers.version.getOrmVersion().match(/^4./)) {
+      this.log(clc.yellow('WARNING: This version of Sequelize CLI is not fully compatible with Sequelize v4. https://github.com/sequelize/cli#sequelize-support'));
+      this.log();
+    }
   },
 
   log: console.log,


### PR DESCRIPTION
Display a warning in the console when using Sequelize CLI v2 with Sequelize v4.

Closes #504 
