### PR TITLE
Add db:create and db:drop for MySQL/Postgres 🎊

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+var
+test

--- a/lib/tasks/db.js
+++ b/lib/tasks/db.js
@@ -11,6 +11,34 @@ var Umzug     = require('umzug');
 var clc       = require('cli-color');
 
 module.exports = {
+  'db:create': {
+    descriptions: {
+      'short': 'Creates the configured database.',
+      'long': [
+        'The command creates the configured database.'
+      ]
+    },
+
+    task: function () {
+      var config = helpers.config.readConfig();
+      var database = config.database;
+      runQueryOnDefaultDatabase('CREATE DATABASE ' + database, config);
+    }
+  },
+  'db:drop': {
+    descriptions: {
+      'short': 'Drops the configured database.',
+      'long': [
+        'The command drops the configured database.'
+      ]
+    },
+
+    task: function () {
+      var config = helpers.config.readConfig();
+      var database = config.database;
+      runQueryOnDefaultDatabase('DROP DATABASE ' + database, config);
+    }
+  },
   'db:migrate': {
     descriptions: {
       'short': 'Run pending migrations.',
@@ -435,6 +463,59 @@ function getMigrator (type) {
     );
     process.exit(1);
   }
+}
+
+function runQueryOnDefaultDatabase(query, config) {
+  var dialect = config.dialect;
+
+  return new Bluebird(function () {
+    if (dialect.match('mysql')) {
+      var mysql = require('mysql');
+      var connection = mysql.createConnection({
+        host: config.host,
+        user: config.username,
+        password: config.password,
+        port: config.port
+      });
+
+      connection.query(query, function (error) {
+        if (error) {
+          console.error(error);
+          process.exit(1);
+        }
+        else {
+          process.exit(0);
+        }
+      });
+    }
+    else if (dialect.match('postgres')) {
+      var Postgres = require('pg').Client;
+      var client = new Postgres({
+        user: config.username,
+        host: config.host,
+        database: 'postgres',
+        password: config.password,
+        port: config.port
+      });
+      client.connect();
+      client.query(query, function (error) {
+        if (error) {
+          console.error(error);
+          process.exit(1);
+        }
+
+        client.end();
+        process.exit(0);
+      });
+    }
+    else {
+      console.log('This command is not supported for this dialect.');
+      process.exit(1);
+    }
+  }).catch(function (err) {
+    console.error(err);
+    process.exit(1);
+  });
 }
 
 /**


### PR DESCRIPTION
Needed for a better dev experience. I didn't use `sequelize` because it doesn't have support for opening a connection without a database, but the dialect libraries work.

Feel free to request any changes.

Solves #70.