### PR TITLE
fix error of creating config directory recursively.

### DIFF
--- a/lib/helpers/config-helper.js
+++ b/lib/helpers/config-helper.js
@@ -94,7 +94,7 @@ var api = {
     var configPath = path.dirname(api.getConfigFile());
 
     if (!helpers.path.existsSync(configPath)) {
-      fs.mkdirSync(configPath);
+      helpers.generic.mkdirp(configPath);
     }
 
     fs.writeFileSync(api.getConfigFile(), api.getDefaultConfig());


### PR DESCRIPTION
Current `mkdirSync` creates a directory successfully only if the parent directory exists.
Error arises in the following example:

create a  `.sequelizerc` file in project root directory, for example:
```js
var path = require('path');

module.exports = {
  'config': path.resolve(__dirname, './db/config/config.js'),
  'migrations-path': path.resolve(__dirname, './db/migrations'),
  'models-path': path.resolve(__dirname, './db/models'),
  'seeders-path': path.resolve(__dirname, './db/seeders')
}
```
execute `./node_modules/.bin/sequelize init`

![se](https://user-images.githubusercontent.com/3142886/29241660-9b18dfee-7fb0-11e7-9eef-1427dd360317.JPG)

