### PR TITLE
Fixing bug when password contains a colon.

### DIFF
--- a/lib/helpers/config-helper.js
+++ b/lib/helpers/config-helper.js
@@ -191,7 +191,7 @@ var api = {
       if (urlParts.auth) {
         result = _.assign(result, {
           username: urlParts.auth.split(':')[0],
-          password: urlParts.auth.split(':')[1]
+          password: urlParts.auth.split(':').slice(1).join(':')
         });
       }
 


### PR DESCRIPTION
Currently if a password contains a colon, cli strips out the colon and anything after it. This small change will account for such situations.