### PR TITLE
Fix in models index template for serverless environment

### DIFF
--- a/lib/assets/models/index.js
+++ b/lib/assets/models/index.js
@@ -3,7 +3,7 @@
 var fs        = require('fs');
 var path      = require('path');
 var Sequelize = require('sequelize');
-var basename  = path.basename(module.filename);
+var basename  = path.basename(__filename);
 var env       = process.env.NODE_ENV || 'development';
 var config    = require(<%= configFile %>)[env];
 var db        = {};


### PR DESCRIPTION
Replaces module.filename with __filename as the former can be undefined when used in a serverless environment.