### PR TITLE
fix(.sequelizerc): options files is not used by all commands

### DIFF
--- a/src/core/yargs.js
+++ b/src/core/yargs.js
@@ -1,3 +1,22 @@
+import fs from 'fs';
+import yargs from 'yargs';
+import path from 'path';
+
+function loadRCFile(optionsPath) {
+  const rcFile = optionsPath || path.resolve(process.cwd(), '.sequelizerc');
+  const rcFileResolved = path.resolve(rcFile);
+  return fs.existsSync(rcFileResolved)
+    ? JSON.parse(JSON.stringify(require(rcFileResolved)))
+    : {};
+}
+
+const args = yargs
+  .config(loadRCFile(yargs.argv.optionsPath));
+
+export default function getYArgs () {
+  return args;
+}
+
 export function _baseOptions (yargs) {
   return yargs
     .option('env', {

--- a/src/helpers/config-helper.js
+++ b/src/helpers/config-helper.js
@@ -4,8 +4,9 @@ import fs from 'fs';
 import url from 'url';
 import _ from 'lodash';
 import helpers from './index';
+import getYArgs from '../core/yargs';
 
-const args = require('yargs').argv;
+const args = getYArgs().argv;
 
 const api = {
   config: undefined,

--- a/src/helpers/generic-helper.js
+++ b/src/helpers/generic-helper.js
@@ -1,7 +1,9 @@
 import path from 'path';
 
 const resolve = require('resolve').sync;
-const args = require('yargs').argv;
+import getYArgs from '../core/yargs';
+
+const args = getYArgs().argv;
 
 const generic = {
   getEnvironment: () => {

--- a/src/helpers/path-helper.js
+++ b/src/helpers/path-helper.js
@@ -2,7 +2,9 @@ import path from 'path';
 import fs from 'fs';
 
 const resolve = require('resolve').sync;
-const args    = require('yargs').argv;
+import getYArgs from '../core/yargs';
+
+const args = getYArgs().argv;
 
 function format (i) {
   return parseInt(i, 10) < 10 ? '0' + i : i;

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import yargs from 'yargs';
-import fs from 'fs';
-import path from 'path';
+import getYArgs from './core/yargs';
 import cliPackage from '../package';
 import Promise from 'bluebird';
 import { isEmpty } from 'lodash';
+
+const yargs = getYArgs();
 
 Promise.coroutine.addYieldHandler(yieldedValue => {
   if (Array.isArray(yieldedValue)) {
@@ -31,6 +31,7 @@ import seedGenerate from './commands/seed_generate';
 
 import helpers from './helpers/index';
 
+
 helpers.view.teaser();
 
 const cli = yargs
@@ -51,7 +52,6 @@ const cli = yargs
   .command(['migration:generate', 'migration:create'], 'Generates a new migration file', migrationGenerate)
   .command(['model:generate', 'model:create'], 'Generates a model and its migration', modelGenerate)
   .command(['seed:generate', 'seed:create'], 'Generates a new seed file', seedGenerate)
-  .config(loadRCFile(yargs.argv.optionsPath))
   .version(() => cliPackage.version)
   .wrap(yargs.terminalWidth())
   .strict()
@@ -63,11 +63,3 @@ const args = cli.argv;
 if (!args._[0]) {
   cli.showHelp();
 }
-
-function loadRCFile(optionsPath) {
-  const rcFile = optionsPath || path.resolve(process.cwd(), '.sequelizerc');
-  const rcFileResolved = path.resolve(rcFile);
-  return fs.existsSync(rcFileResolved)
-    ? JSON.parse(JSON.stringify(require(rcFileResolved)))
-    : {};
-};

--- a/test/db/migrate.test.js
+++ b/test/db/migrate.test.js
@@ -174,10 +174,8 @@ describe(Support.getTestDialectTeaser('db:migrate'), () => {
     };
 
     it('creates a SequelizeMeta table', function (done) {
-      const self = this;
-
       prepare(() => {
-        helpers.readTables(self.sequelize, tables => {
+        helpers.readTables(this.sequelize, tables => {
           expect(tables).to.have.length(2);
           expect(tables).to.contain('SequelizeMeta');
           done();
@@ -186,10 +184,8 @@ describe(Support.getTestDialectTeaser('db:migrate'), () => {
     });
 
     it('creates the respective table', function (done) {
-      const self = this;
-
       prepare(() => {
-        helpers.readTables(self.sequelize, tables => {
+        helpers.readTables(this.sequelize, tables => {
           expect(tables).to.have.length(2);
           expect(tables).to.contain('Person');
           done();

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,6 +1,6 @@
-const Support     = require(__dirname + '/support');
-const helpers     = require(__dirname + '/support/helpers');
-const gulp        = require('gulp');
+const Support = require(__dirname + '/support');
+const helpers = require(__dirname + '/support/helpers');
+const gulp = require('gulp');
 const optionsPath = Support.resolveSupportPath('config', 'options.js');
 
 describe(Support.getTestDialectTeaser('options'), () => {
@@ -22,18 +22,29 @@ describe(Support.getTestDialectTeaser('options'), () => {
   });
 
   describe('.sequelizerc', () => {
-    it('uses the .sequelizerc file', done => {
+    it('uses .sequelizerc file', done => {
+      const configContent = `
+        var path = require('path');
+
+        module.exports = {
+          'config':          path.resolve('config-new', 'database.json'),
+          'migrations-path': path.resolve('migrations-new')
+        };
+      `;
+
       gulp
         .src(Support.resolveSupportPath('tmp'))
         .pipe(helpers.clearDirectory())
         .pipe(helpers.copyFile(optionsPath, '.sequelizerc'))
+        .pipe(helpers.overwriteFile(configContent, '.sequelizerc'))
         .pipe(helpers.runCli('init'))
         .pipe(helpers.listFiles())
-        .pipe(helpers.ensureContent('models'))
+        .pipe(helpers.ensureContent('migrations-new'))
+        .pipe(helpers.ensureContent('config-new'))
         .pipe(helpers.teardown(done));
     });
 
-    it('prefers the CLI arguments over the sequelizerc file', done => {
+    it('prefers CLI arguments over .sequelizerc file', done => {
       const configPath = Support.resolveSupportPath('tmp', 'config', 'config.js');
 
       gulp


### PR DESCRIPTION
Closes https://github.com/sequelize/cli/issues/536

Older helpers were still directly loading `yargs` which was not configured to read `.sequelizerc` file. Now a single `yargs` instance in used to fix this issue. Added tests to prevent regressions.