### PR TITLE
Bug/postgres hyphenated db names

### DIFF
--- a/src/commands/database.js
+++ b/src/commands/database.js
@@ -17,6 +17,12 @@ exports.handler = async function (args) {
   const sequelize = getDatabaseLessSequelize();
   const config = helpers.config.readConfig();
 
+  switch (config.dialect) {
+    case 'postgres':
+      config.database = `"${config.database}"`;
+      break;
+  }
+
   switch (command) {
     case 'db:create':
       await sequelize.query(`CREATE DATABASE ${config.database}`, {

--- a/test/db/db-create.test.js
+++ b/test/db/db-create.test.js
@@ -24,7 +24,7 @@ const prepare = function (flag, callback, options) {
 describe(Support.getTestDialectTeaser('db:create'), () => {
   if (Support.dialectIsPostgres()) {
     it('correctly creates database', function (done) {
-      const databaseName = `my_test_db_${_.random(10000, 99999)}`;
+      const databaseName = `my-test-db-${_.random(10000, 99999)}`;
       prepare(
         'db:create',
         () => {

--- a/test/db/db-drop.test.js
+++ b/test/db/db-drop.test.js
@@ -25,7 +25,7 @@ const prepare = function (flag, callback, options) {
 describe(Support.getTestDialectTeaser('db:drop'), () => {
   if (Support.dialectIsPostgres()) {
     it('correctly drops database', function (done) {
-      const databaseName = `my_test_db_${_.random(10000, 99999)}`;
+      const databaseName = `my-test-db-${_.random(10000, 99999)}`;
       prepare(
         'db:drop',
         () => {


### PR DESCRIPTION
Addresses issues in https://github.com/sequelize/cli/issues/545
- Wrap database name with quotes in create and drop scripts, if dialect is Postgres.
- Update tests to use hyphens in Postgres create and drop db tests, to prevent regression.