### PR TITLE
Add option for searchPath when the connection is set by URL

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,11 @@ use the `--url` option to pass in a connection string. For example:
 
 `sequelize db:migrate --url 'mysql://root:password@mysql_host.com/database_name'`
 
+If you are using PostgreSQL, then there is an optional `searchPath` query parameter to set the search path before each query.
+This is useful when you are migrating the same file into different _schemas_ (tenants). 
+
+`sequelize db:migrate --url 'postgres://root:password@postgres_host.com/database_name?searchPath=myCustomSchema'`
+
 ### Configuration Connection Environment Variable
 
 Another possibility is to store the URL in an environment variable and to tell

--- a/src/helpers/config-helper.js
+++ b/src/helpers/config-helper.js
@@ -158,19 +158,29 @@ const api = {
 
   urlStringToConfigHash (urlString) {
     try {
-      const urlParts = url.parse(urlString);
+      const urlParts = url.parse(urlString, true);
       let result   = {
         database: urlParts.pathname.replace(/^\//,  ''),
         host:     urlParts.hostname,
         port:     urlParts.port,
         protocol: urlParts.protocol.replace(/:$/, ''),
-        ssl:      urlParts.query ? urlParts.query.indexOf('ssl=true') >= 0 : false
+        ssl:      (urlParts.query && urlParts.query.ssl === 'true')
       };
 
       if (urlParts.auth) {
         result = _.assign(result, {
           username: urlParts.auth.split(':')[0],
           password: urlParts.auth.split(':')[1]
+        });
+      }
+
+      // If there is a search path key in the URL, then the prependSearchPath is being activated.
+      if (urlParts.protocol === 'postgres' && urlParts.searchPath) {
+        result = _.assign(result, {
+          searchPath:     urlParts.searchPath,
+          dialectOptions: {
+            prependSearchPath: true,
+          }
         });
       }
 


### PR DESCRIPTION
Minor addition which is useful when migrating into multiple schemas.
We had an issue when the same migration is needed in dozens of schemas, already applied and using this simple solution. 

It's not breaking anything but adds a way to solve issue like #284 and any other multi tenant application ^.^