### PR TITLE
Use const for model definition

### DIFF
--- a/src/assets/models/model.js
+++ b/src/assets/models/model.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = (sequelize, DataTypes) => {
-  var <%= name %> = sequelize.define('<%= name %>', {
+  const <%= name %> = sequelize.define('<%= name %>', {
     <% attributes.forEach(function(attribute, index) { %>
       <%= attribute.fieldName %>: DataTypes.<%= attribute.dataFunction ? `${attribute.dataFunction.toUpperCase()}(DataTypes.${attribute.dataType.toUpperCase()})` : attribute.dataType.toUpperCase() %>
       <%= (Object.keys(attributes).length - 1) > index ? ',' : '' %>


### PR DESCRIPTION
When running the `model:generate` command, it generates files and uses `var` for the model definition.

I changed it so that it uses the better keyword `const`.