### PR TITLE
Adds in force flag for model:create

### DIFF
--- a/src/commands/model_generate.js
+++ b/src/commands/model_generate.js
@@ -17,6 +17,11 @@ exports.builder =
           type: 'string',
           demandOption: true
         })
+        .option('force', {
+          describe: 'Forcefully re-creates model with the same name',
+          type: 'string',
+          demandOption: false
+        })
     )
       .help()
       .argv;


### PR DESCRIPTION
Currently if model:create tries to recreate the migration and model
files for the same name, the user is asked to use the --force flag which
does not currently work as it is not being accepted currently. This
allows --force with value true

Fixes #638