### PR TITLE
Add model:generate attribute datatype validation

### DIFF
--- a/src/commands/model_generate.js
+++ b/src/commands/model_generate.js
@@ -31,7 +31,13 @@ exports.handler = function (args) {
   ensureMigrationsFolder();
   checkModelFileExistence(args);
 
-  helpers.model.generateFile(args);
+
+  try {
+    helpers.model.generateFile(args);
+  } catch (err) {
+    helpers.view.error(err.message);
+  }
+
   helpers.migration.generateTableCreationFile(args);
   helpers.view.log(
     'New model was created at',

--- a/src/helpers/model-helper.js
+++ b/src/helpers/model-helper.js
@@ -1,6 +1,19 @@
 import helpers from './index';
+import { DataTypes } from 'sequelize';
 
 const validAttributeFunctionType = 'array';
+
+/**
+ * Check the given dataType actual exists.
+ * @param {string} dataType
+ */
+function validateDataType (dataType) {
+  if (!DataTypes[dataType.toUpperCase()]) {
+    throw new Error(`Unknown type '${dataType}'`);
+  }
+
+  return dataType;
+}
 
 function formatAttributes (attribute) {
   let result;
@@ -28,18 +41,19 @@ module.exports = {
       - 'first_name:string, last_name:string, bio:text, reviews:array:string'
     */
 
-    const set    = flag.replace(/,/g, ' ').split(/\s+/);
-    const result = [];
+    const attributeStrings = flag.replace(/,/g, ' ').split(/\s+/);
 
-    set.forEach(attribute => {
+    return attributeStrings.map(attribute => {
       const formattedAttribute = formatAttributes(attribute);
 
-      if (formattedAttribute) {
-        result.push(formattedAttribute);
+      try {
+        validateDataType(formattedAttribute.dataType);
+      } catch (err) {
+        throw new Error(`Attribute '${attribute}' cannot be parsed: ${err.message}`);
       }
-    });
 
-    return result;
+      return formattedAttribute;
+    });
   },
 
   generateFileContent (args) {

--- a/test/model/create.test.js
+++ b/test/model/create.test.js
@@ -75,6 +75,15 @@ const _         = require('lodash');
         });
       });
 
+      describe('when passed an invalid data type', () => {
+        it('exits with an error code', done => {
+          prepare({
+            flags: { name: 'User', attributes: 'badAttribute:datetime' },
+            cli: { exitCode: 1 }
+          }, done);
+        });
+      })
+
       ;[
         'first_name:string,last_name:string,bio:text,reviews:array:text',
         '\'first_name:string last_name:string bio:text reviews:array:text\'',

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -74,7 +74,7 @@ module.exports = {
             expect(err.code).to.equal(1);
             callback(null, result);
           } catch (e) {
-            callback(e, result);
+            callback(new Error('Expected cli to exit with a non-zero code'), null);
           }
         } else {
           err = options.pipeStderr ? null : err;


### PR DESCRIPTION
I ran into a small problem today when generating some models, it's pretty easy to mistakenly write something like 'someDate:datetime' as an attribute when it is just 'someDate:date'. The generate command lets it slide and then you end up with some [hard to debug .toString() errors](https://stackoverflow.com/questions/46034605/sequelize-cannot-read-property-tostring-of-undefined) by when migrating.

I've added an error condition which halts the generation if any of the attributes contain an invalid DataType.

Also, I noticed that `runCli()` in `test/support/helpers.js` wasn't correctly asserting a non-zero error code so I fixed it by not passing through result.