### PR TITLE
Make the `--force` a real flag

### DIFF
--- a/src/commands/model_generate.js
+++ b/src/commands/model_generate.js
@@ -76,7 +76,7 @@ function ensureMigrationsFolder () {
 function checkModelFileExistence (args) {
   const modelPath = helpers.path.getModelPath(args.name);
 
-  if (!args.force && helpers.model.modelFileExists(modelPath)) {
+  if (args.force === undefined && helpers.model.modelFileExists(modelPath)) {
     helpers.view.notifyAboutExistingFile(modelPath);
     process.exit(1);
   }


### PR DESCRIPTION
Make the "--force" a real flag that does not require anything after it. Fix #690

## The old code:
```javascipt
if (!args.force && helpers.model.modelFileExists(modelPath)) {
```
make the `sequelize ... --force` useless because `args.force` is a `''` which yields `!args.force` to be `true`. And the system will ask the user to add `--force` again. That's what I encountered in #690.

In a nutshell, we need to add something after the `--force` to make it work **in this old situation**.
## Now it is:
```javascript
if (args.force === undefined && helpers.model.modelFileExists(modelPath)) {
```
so when the user adds `--force`, the `args.force` is not `undefined`, so everything is OK.

## Test
I compiled it and run `npm test` and it passed.