### PR TITLE
 feat(db:create): support options on db:create

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
     ports:
       - "54320:5432"
     container_name: postgres
+    command: >
+      bash -c "sed -i -e 's/# \(zh_TW\|en_US\).UTF-8 UTF-8/\1.UTF-8 UTF-8/' /etc/locale.gen
+      && locale-gen
+      && docker-entrypoint.sh postgres"
 
   # MySQL
   mysql:

--- a/test/db/db-create.test.js
+++ b/test/db/db-create.test.js
@@ -58,6 +58,58 @@ describe(Support.getTestDialectTeaser('db:create'), () => {
           }
         });
     });
+
+    it('correctly creates database with encoding, collate and template', function (done) {
+      const databaseName = `my_test-db_${_.random(10000, 99999)}`;
+      prepare(
+        'db:create --encoding UTF8 --collate zh_TW.UTF-8 --template template0',
+        () => {
+          this.sequelize.query(`SELECT
+            1 as exists,
+            pg_encoding_to_char(encoding) as encoding,
+            datcollate as collate,
+            datctype as ctype
+            FROM pg_database WHERE datname = '${databaseName}';`, {
+            type: this.sequelize.QueryTypes.SELECT
+          }).then(result => {
+            expect(result[0].exists).to.eql(1);
+            expect(result[0].encoding).to.eql('UTF8');
+            expect(result[0].collate).to.eql('zh_TW.UTF-8');
+            expect(result[0].ctype).to.eql('en_US.utf8');
+            done();
+          });
+        }, {
+          config: {
+            database: databaseName
+          }
+        });
+    });
+
+    it('correctly creates database with encoding, collate, ctype and template', function (done) {
+      const databaseName = `my_test-db_${_.random(10000, 99999)}`;
+      prepare(
+        'db:create --encoding UTF8 --collate zh_TW.UTF-8 --ctype zh_TW.UTF-8 --template template0',
+        () => {
+          this.sequelize.query(`SELECT
+            1 as exists,
+            pg_encoding_to_char(encoding) as encoding,
+            datcollate as collate,
+            datctype as ctype
+            FROM pg_database WHERE datname = '${databaseName}';`, {
+            type: this.sequelize.QueryTypes.SELECT
+          }).then(result => {
+            expect(result[0].exists).to.eql(1);
+            expect(result[0].encoding).to.eql('UTF8');
+            expect(result[0].collate).to.eql('zh_TW.UTF-8');
+            expect(result[0].ctype).to.eql('zh_TW.UTF-8');
+            done();
+          });
+        }, {
+          config: {
+            database: databaseName
+          }
+        });
+    });
   }
 
   if (Support.dialectIsMySQL()) {
@@ -88,6 +140,50 @@ describe(Support.getTestDialectTeaser('db:create'), () => {
             type: this.sequelize.QueryTypes.SELECT
           }).then(result => {
             expect(result[0].found).to.eql(1);
+            done();
+          });
+        }, {
+          config: {
+            database: databaseName
+          }
+        });
+    });
+
+    it('correctly creates database with charset', function (done) {
+      const databaseName = `my_test-db_${_.random(10000, 99999)}`;
+      prepare(
+        'db:create --charset utf8mb4',
+        () => {
+          this.sequelize.query(`SELECT
+            DEFAULT_CHARACTER_SET_NAME as charset,
+            DEFAULT_COLLATION_NAME as collation
+            FROM information_schema.SCHEMATA WHERE schema_name = '${databaseName}';`, {
+            type: this.sequelize.QueryTypes.SELECT
+          }).then(result => {
+            expect(result[0].charset).to.eql('utf8mb4');
+            expect(result[0].collation).to.eql('utf8mb4_generic_ui');
+            done();
+          });
+        }, {
+          config: {
+            database: databaseName
+          }
+        });
+    });
+  
+    it('correctly creates database with charset and collation', function (done) {
+      const databaseName = `my_test-db_${_.random(10000, 99999)}`;
+      prepare(
+        'db:create --charset utf8mb4 --collate utf8mb4_unicode_ui',
+        () => {
+          this.sequelize.query(`SELECT
+            DEFAULT_CHARACTER_SET_NAME as charset,
+            DEFAULT_COLLATION_NAME as collation
+            FROM information_schema.SCHEMATA WHERE schema_name = '${databaseName}';`, {
+            type: this.sequelize.QueryTypes.SELECT
+          }).then(result => {
+            expect(result[0].charset).to.eql('utf8mb4');
+            expect(result[0].collation).to.eql('utf8mb4_unicode_ui');
             done();
           });
         }, {

--- a/test/db/db-create.test.js
+++ b/test/db/db-create.test.js
@@ -174,7 +174,7 @@ describe(Support.getTestDialectTeaser('db:create'), () => {
     it('correctly creates database with charset and collation', function (done) {
       const databaseName = `my_test-db_${_.random(10000, 99999)}`;
       prepare(
-        'db:create --charset utf8mb4 --collate utf8mb4_unicode_ui',
+        'db:create --charset utf8mb4 --collate utf8mb4_unicode_ci',
         () => {
           this.sequelize.query(`SELECT
             DEFAULT_CHARACTER_SET_NAME as charset,
@@ -183,7 +183,7 @@ describe(Support.getTestDialectTeaser('db:create'), () => {
             type: this.sequelize.QueryTypes.SELECT
           }).then(result => {
             expect(result[0].charset).to.eql('utf8mb4');
-            expect(result[0].collation).to.eql('utf8mb4_unicode_ui');
+            expect(result[0].collation).to.eql('utf8mb4_unicode_ci');
             done();
           });
         }, {

--- a/test/db/db-create.test.js
+++ b/test/db/db-create.test.js
@@ -161,7 +161,7 @@ describe(Support.getTestDialectTeaser('db:create'), () => {
             type: this.sequelize.QueryTypes.SELECT
           }).then(result => {
             expect(result[0].charset).to.eql('utf8mb4');
-            expect(result[0].collation).to.eql('utf8mb4_generic_ui');
+            expect(result[0].collation).to.eql('utf8mb4_general_ci');
             done();
           });
         }, {


### PR DESCRIPTION
resolved #698
resolved #590
resolved #629

Use `queryInterface.(create|drop)Database`. So now we can:
- Pass option to specify charset, collate... .
- Use `IF NOT EXISTS` on database create and `IF EXISTS` on database drop. (postgresql not support `IF NOT EXISTS` on database)

But it's dependent on https://github.com/sequelize/sequelize/commit/198cb52dcf702db98e6d7805a9c1fd27abdc695b . Not for release version now.

BTW. @sushantdhiman When is the release time of `sequelize/master` ? Is it for sequelize version 5?
