### PR TITLE
feat(db:create): support options on db:create with sequelize@4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
     ports:
       - "54320:5432"
     container_name: postgres
+    command: >
+      bash -c "sed -i -e 's/# \(zh_TW\|en_US\).UTF-8 UTF-8/\1.UTF-8 UTF-8/' /etc/locale.gen
+      && locale-gen
+      && docker-entrypoint.sh postgres"
 
   # MySQL
   mysql:

--- a/src/commands/database.js
+++ b/src/commands/database.js
@@ -2,12 +2,37 @@ import { _baseOptions } from '../core/yargs';
 import { logMigrator } from '../core/migrator';
 
 import helpers from '../helpers';
-import { cloneDeep, defaults } from 'lodash';
+import { cloneDeep, defaults, pick } from 'lodash';
 import clc from 'cli-color';
 
 const Sequelize = helpers.generic.getSequelize();
 
-exports.builder = yargs => _baseOptions(yargs).help().argv;
+exports.builder =
+  yargs =>
+    _baseOptions(yargs)
+      .option('charset', {
+        describe: 'Pass charset option to dialect, MYSQL only',
+        type: 'string'
+      })
+      .option('collate', {
+        describe: 'Pass collate option to dialect',
+        type: 'string'
+      })
+      .option('encoding', {
+        describe: 'Pass encoding option to dialect, PostgreSQL only',
+        type: 'string'
+      })
+      .option('ctype', {
+        describe: 'Pass ctype option to dialect, PostgreSQL only',
+        type: 'string'
+      })
+      .option('template', {
+        describe: 'Pass template option to dialect, PostgreSQL only',
+        type: 'string'
+      })
+      .help()
+      .argv;
+
 exports.handler = async function (args) {
   const command = args._[0];
 
@@ -19,7 +44,17 @@ exports.handler = async function (args) {
 
   switch (command) {
     case 'db:create':
-      await sequelize.query(`CREATE DATABASE ${sequelize.getQueryInterface().quoteIdentifier(config.database)}`, {
+      const options = pick(args, [
+        'charset',
+        'collate',
+        'encoding',
+        'ctype',
+        'template'
+      ]);
+
+      const query = getCreateDatabaseQuery(sequelize, config, options);
+
+      await sequelize.query(query, {
         type: sequelize.QueryTypes.RAW
       }).catch(e => helpers.view.error(e));
 
@@ -46,6 +81,35 @@ exports.handler = async function (args) {
 
   process.exit(0);
 };
+
+function getCreateDatabaseQuery (sequelize, config, options) {
+  switch (config.dialect) {
+    case 'postgres':
+    case 'postgres-native':
+      return 'CREATE DATABASE ' + sequelize.getQueryInterface().quoteIdentifier(config.database)
+        + (options.encoding ? ' ENCODING = '   + sequelize.getQueryInterface().quoteIdentifier(options.encoding) : '')
+        + (options.collate  ? ' LC_COLLATE = ' + sequelize.getQueryInterface().quoteIdentifier(options.collate)  : '')
+        + (options.ctype    ? ' LC_CTYPE = '   + sequelize.getQueryInterface().quoteIdentifier(options.ctype)    : '')
+        + (options.template ? ' TEMPLATE = '   + sequelize.getQueryInterface().quoteIdentifier(options.template) : '');
+
+    case 'mysql':
+      return 'CREATE DATABASE IF NOT EXISTS ' + sequelize.getQueryInterface().quoteIdentifier(config.database)
+        + (options.charset ? ' DEFAULT CHARACTER SET ' + sequelize.getQueryInterface().quoteIdentifier(options.charset) : '')
+        + (options.collate ? ' DEFAULT COLLATE '       + sequelize.getQueryInterface().quoteIdentifier(options.collate) : '');
+
+    case 'mssql':
+      return 'IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = \'', config.database, '\')'
+        + 'BEGIN'
+        + 'CREATE DATABASE ' + sequelize.getQueryInterface().escape(config.database)
+        + (options.collate ? ' COLLATE ' + sequelize.getQueryInterface().escape(options.collate) : '')
+        + 'END;';
+      break;
+
+    default:
+      helpers.view.error(`Dialect ${config.dialect} does not support db:create / db:drop commands`);
+      return 'CREATE DATABASE ' + sequelize.getQueryInterface().quoteIdentifier(config.database);
+  }
+}
 
 function getDatabaseLessSequelize () {
   let config = null;

--- a/test/db/db-create.test.js
+++ b/test/db/db-create.test.js
@@ -58,6 +58,58 @@ describe(Support.getTestDialectTeaser('db:create'), () => {
           }
         });
     });
+
+    it('correctly creates database with encoding, collate and template', function (done) {
+      const databaseName = `my_test-db_${_.random(10000, 99999)}`;
+      prepare(
+        'db:create --encoding UTF8 --collate zh_TW.UTF-8 --template template0',
+        () => {
+          this.sequelize.query(`SELECT
+           1 as exists,
+           pg_encoding_to_char(encoding) as encoding,
+           datcollate as collate,
+           datctype as ctype
+           FROM pg_database WHERE datname = '${databaseName}';`, {
+            type: this.sequelize.QueryTypes.SELECT
+          }).then(result => {
+            expect(result[0].exists).to.eql(1);
+            expect(result[0].encoding).to.eql('UTF8');
+            expect(result[0].collate).to.eql('zh_TW.UTF-8');
+            expect(result[0].ctype).to.eql('en_US.utf8');
+            done();
+          });
+        }, {
+          config: {
+            database: databaseName
+          }
+        });
+    });
+
+    it('correctly creates database with encoding, collate, ctype and template', function (done) {
+      const databaseName = `my_test-db_${_.random(10000, 99999)}`;
+      prepare(
+        'db:create --encoding UTF8 --collate zh_TW.UTF-8 --ctype zh_TW.UTF-8 --template template0',
+        () => {
+          this.sequelize.query(`SELECT
+           1 as exists,
+           pg_encoding_to_char(encoding) as encoding,
+           datcollate as collate,
+           datctype as ctype
+           FROM pg_database WHERE datname = '${databaseName}';`, {
+            type: this.sequelize.QueryTypes.SELECT
+          }).then(result => {
+            expect(result[0].exists).to.eql(1);
+            expect(result[0].encoding).to.eql('UTF8');
+            expect(result[0].collate).to.eql('zh_TW.UTF-8');
+            expect(result[0].ctype).to.eql('zh_TW.UTF-8');
+            done();
+          });
+        }, {
+          config: {
+            database: databaseName
+          }
+        });
+    });
   }
 
   if (Support.dialectIsMySQL()) {
@@ -88,6 +140,51 @@ describe(Support.getTestDialectTeaser('db:create'), () => {
             type: this.sequelize.QueryTypes.SELECT
           }).then(result => {
             expect(result[0].found).to.eql(1);
+            done();
+          });
+        }, {
+          config: {
+            database: databaseName
+          }
+        });
+    });
+
+    it('correctly creates database with charset', function (done) {
+      const databaseName = `my_test-db_${_.random(10000, 99999)}`;
+      prepare(
+        'db:create --charset utf8mb4',
+        () => {
+          this.sequelize.query(`SELECT
+            DEFAULT_CHARACTER_SET_NAME as charset,
+            DEFAULT_COLLATION_NAME as collation
+            FROM information_schema.SCHEMATA WHERE schema_name = '${databaseName}';`, {
+            type: this.sequelize.QueryTypes.SELECT
+          }).then(result => {
+            expect(result[0].charset).to.eql('utf8mb4');
+            expect(result[0].collation).to.eql('utf8mb4_general_ci');
+            done();
+          });
+        }, {
+          config: {
+            database: databaseName
+          }
+        });
+    });
+  
+
+    it('correctly creates database with charset and collation', function (done) {
+      const databaseName = `my_test-db_${_.random(10000, 99999)}`;
+      prepare(
+        'db:create --charset utf8mb4 --collate utf8mb4_unicode_ci',
+        () => {
+          this.sequelize.query(`SELECT
+            DEFAULT_CHARACTER_SET_NAME as charset,
+            DEFAULT_COLLATION_NAME as collation
+            FROM information_schema.SCHEMATA WHERE schema_name = '${databaseName}';`, {
+            type: this.sequelize.QueryTypes.SELECT
+          }).then(result => {
+            expect(result[0].charset).to.eql('utf8mb4');
+            expect(result[0].collation).to.eql('utf8mb4_unicode_ci');
             done();
           });
         }, {


### PR DESCRIPTION
same as #699 
But it's a patch with `sequelize@4`. No `create/dropDatabase` used.

resolved #698
resolved #590
resolved #629