### PR TITLE
feat(model:create): Add option to create ES6 class model

### DIFF
--- a/src/assets/models/class-model.js
+++ b/src/assets/models/class-model.js
@@ -1,0 +1,23 @@
+const { Model } = require('sequelize');
+<%= '\n' %>
+class <%= name %> extends Model {
+  static init(sequelize, DataTypes) {
+    return super.init({
+      <% attributes.forEach(function(attribute, index) { %>
+        <%= attribute.fieldName %>: DataTypes.<%= attribute.dataFunction ? `${attribute.dataFunction.toUpperCase()}(DataTypes.${attribute.dataType.toUpperCase()})` : attribute.dataValues ? `${attribute.dataType.toUpperCase()}(${attribute.dataValues})` : attribute.dataType.toUpperCase() %>
+        <%= (Object.keys(attributes).length - 1) > index ? ',' : '' %>
+      <% }) %>
+      },
+      {
+        sequelize,
+        <%= underscored ? 'underscored: true,' : '' %>
+      }
+    )
+  }
+
+  static associate(models) {
+    // associations can be defined here
+  }
+}
+
+module.exports = <%= name %>;

--- a/src/commands/model_generate.js
+++ b/src/commands/model_generate.js
@@ -22,6 +22,11 @@ exports.builder =
           type: 'string',
           demandOption: false
         })
+        .option('class', {
+          describe: 'Generate ES6 class model',
+          default: false,
+          type: 'boolean'
+        })
     )
       .help()
       .argv;

--- a/src/helpers/model-helper.js
+++ b/src/helpers/model-helper.js
@@ -57,11 +57,17 @@ module.exports = {
   },
 
   generateFileContent (args) {
-    return helpers.template.render('models/model.js', {
-      name:       args.name,
-      attributes: this.transformAttributes(args.attributes),
-      underscored: args.underscored
-    });
+    return args.class
+      ? helpers.template.render('models/class-model.js', {
+        name:       args.name,
+        attributes: this.transformAttributes(args.attributes),
+        underscored: args.underscored
+      })
+      : helpers.template.render('models/model.js', {
+        name:       args.name,
+        attributes: this.transformAttributes(args.attributes),
+        underscored: args.underscored
+      });
   },
 
   generateFile (args) {

--- a/test/model/create.test.js
+++ b/test/model/create.test.js
@@ -252,5 +252,65 @@ const _         = require('lodash');
         });
       });
     });
+
+    describe('class', () => {
+      ;[
+        'first_name:string,last_name:string,bio:text,reviews:array:text',
+        '\'first_name:string last_name:string bio:text reviews:array:text\'',
+        '\'first_name:string, last_name:string, bio:text, reviews:array:text\''
+      ].forEach(attributes => {
+        describe('--attributes ' + attributes, () => {
+          it('exits with exit code 0', done => {
+            prepare({
+              flags: { name: 'User', attributes, class: true },
+              cli: { exitCode: 0 }
+            }, done);
+          });
+
+          it('creates the model file', done => {
+            prepare({
+              flags: { name: 'User', attributes, class: true }
+            }, () => {
+              gulp
+                .src(Support.resolveSupportPath('tmp', 'models'))
+                .pipe(helpers.listFiles())
+                .pipe(helpers.ensureContent('user.js'))
+                .pipe(helpers.teardown(done));
+            });
+          });
+
+          it('generates the model attributes correctly', done => {
+            prepare({
+              flags: { name: 'User', attributes, class: true }
+            }, () => {
+              gulp
+                .src(Support.resolveSupportPath('tmp', 'models'))
+                .pipe(helpers.readFile('user.js'))
+                .pipe(helpers.ensureContent('class User extends Model {'))
+                .pipe(helpers.ensureContent('first_name: DataTypes.STRING'))
+                .pipe(helpers.ensureContent('last_name: DataTypes.STRING'))
+                .pipe(helpers.ensureContent('bio: DataTypes.TEXT'))
+                .pipe(helpers.ensureContent('reviews: DataTypes.ARRAY(DataTypes.TEXT)'))
+                .pipe(helpers.ensureContent('module.exports = User;'))
+                .pipe(helpers.teardown(done));
+            });
+          });
+
+          it('generates the model init and associate', done => {
+            prepare({
+              flags: { name: 'User', attributes, class: true }
+            }, () => {
+              gulp
+                .src(Support.resolveSupportPath('tmp', 'models'))
+                .pipe(helpers.readFile('user.js'))
+                .pipe(helpers.ensureContent('static init'))
+                .pipe(helpers.ensureContent('static init(sequelize, DataTypes)'))
+                .pipe(helpers.ensureContent('static associate(models)'))
+                .pipe(helpers.teardown(done));
+            });
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Sequelize CLI master tests aren't passing (some issue with the `enum` changes) so this is branching from `5.2.0`, happy to rebase/merge and double-check tests are passing once that's sorted.

Also feel free to close this and the associated issue https://github.com/sequelize/cli/issues/678 as a "won't do" 😄

- Add a class-model template that uses an ES6 class (`extends Sequelize.Model`)
- Add --class option to args parser.
- Use class-model template when --class passed.
- Add tests for --class option.