### PR TITLE
Allow both ts and js files to run migrations

### DIFF
--- a/src/core/migrator.js
+++ b/src/core/migrator.js
@@ -48,7 +48,7 @@ export function getMigrator (type, args) {
       migrations: {
         params: [sequelize.getQueryInterface(), Sequelize],
         path: helpers.path.getPath(type),
-        pattern: /\.js$/,
+        pattern: /\.(t|j)s$/,
         wrap: fun => {
           if (fun.length === 3) {
             return Bluebird.promisify(fun);


### PR DESCRIPTION
Because you can use `ts-node node_modules/.bin/sequelize db:migrate` to trigger your migrations, you can safely use TypeScript using more or less vanilla sequelize-cli. The only blocker I've found so far is the check for js files in the migration file detection. 

This is great, because you get awesome tooling support

<img width="1185" alt="screen shot 2018-11-08 at 7 14 16 pm" src="https://user-images.githubusercontent.com/49038/48235198-f3330800-e38a-11e8-83f6-6db6d412e230.png">

This PR allows a `.ts` file as well as a `.js` to pass by default.

```
> "hello.ts".match(/\.(t|j)s$/)
< [".ts", "t"] (2)
> "hello.js".match(/\.(t|j)s$/)
< [".js", "j"] (2)
> "hello.coffee".match(/\.(t|j)s$/)
< null
```

There's a downside to this in that someone could try running a typescript file without the `ts-node`, but this app is not documented as supporting typescript out of the box, so I don't think people would have that expectation.