### PR TITLE
fix: show commands with --help

### DIFF
--- a/src/commands/database.js
+++ b/src/commands/database.js
@@ -30,7 +30,6 @@ exports.builder =
         describe: 'Pass template option to dialect, PostgreSQL only',
         type: 'string'
       })
-      .help()
       .argv;
 
 exports.handler = async function (args) {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -7,7 +7,6 @@ exports.builder = yargs => _baseOptions(yargs)
     type: 'boolean',
     default: false
   })
-  .help()
   .argv;
 
 exports.handler = async function (argv) {

--- a/src/commands/migrate.js
+++ b/src/commands/migrate.js
@@ -13,8 +13,8 @@ exports.builder = yargs => _baseOptions(yargs)
     describe: 'Migration name to start migrations from (excluding)',
     type: 'string'
   })
-  .help()
   .argv;
+
 exports.handler = async function (args) {
   const command = args._[0];
 

--- a/src/commands/migrate_undo.js
+++ b/src/commands/migrate_undo.js
@@ -10,7 +10,6 @@ exports.builder =
         describe: 'Name of the migration to undo',
         type: 'string'
       })
-      .help()
       .argv;
 
 exports.handler = async function (args) {

--- a/src/commands/migrate_undo_all.js
+++ b/src/commands/migrate_undo_all.js
@@ -11,7 +11,6 @@ exports.builder =
         default: 0,
         type: 'string'
       })
-      .help()
       .argv;
 
 exports.handler = async function (args) {

--- a/src/commands/migration_generate.js
+++ b/src/commands/migration_generate.js
@@ -14,7 +14,6 @@ exports.builder =
           demandOption: true
         })
     )
-      .help()
       .argv;
 
 exports.handler = function (args) {

--- a/src/commands/model_generate.js
+++ b/src/commands/model_generate.js
@@ -23,7 +23,6 @@ exports.builder =
           demandOption: false
         })
     )
-      .help()
       .argv;
 
 exports.handler = function (args) {

--- a/src/commands/seed.js
+++ b/src/commands/seed.js
@@ -4,7 +4,7 @@ import { getMigrator } from '../core/migrator';
 import helpers from '../helpers';
 import _ from 'lodash';
 
-exports.builder = yargs => _baseOptions(yargs).help().argv;
+exports.builder = yargs => _baseOptions(yargs).argv;
 exports.handler = async function (args) {
   const command = args._[0];
 

--- a/src/commands/seed_generate.js
+++ b/src/commands/seed_generate.js
@@ -12,7 +12,6 @@ exports.builder =
         type: 'string',
         demandOption: true
       })
-      .help()
       .argv;
 
 exports.handler = function (args) {

--- a/src/commands/seed_one.js
+++ b/src/commands/seed_one.js
@@ -11,7 +11,6 @@ exports.builder =
         describe: 'List of seed files',
         type: 'array'
       })
-      .help()
       .argv;
 
 exports.handler = async function (args) {

--- a/src/core/yargs.js
+++ b/src/core/yargs.js
@@ -11,6 +11,8 @@ function loadRCFile(optionsPath) {
 }
 
 const args = yargs
+  .help(false)
+  .version(false)
   .config(loadRCFile(yargs.argv.optionsPath));
 
 export default function getYArgs () {

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -34,6 +34,8 @@ import helpers from './helpers/index';
 helpers.view.teaser();
 
 const cli = yargs
+  .help()
+  .version()
   .command('db:migrate', 'Run pending migrations', migrate)
   .command('db:migrate:schema:timestamps:add', 'Update migration table to have timestamps', migrate)
   .command('db:migrate:status', 'List the status of all migrations', migrate)
@@ -54,8 +56,7 @@ const cli = yargs
   .command(['model:generate', 'model:create'], 'Generates a model and its migration', modelGenerate)
   .command(['seed:generate', 'seed:create'], 'Generates a new seed file', seedGenerate)
   .wrap(yargs.terminalWidth())
-  .strict()
-  .help();
+  .strict();
 
 const args = cli.argv;
 


### PR DESCRIPTION
Fixes https://github.com/sequelize/cli/issues/707

# Issue
When `--help` or `version` are provided, yargs exit the process before loading the commands and the view helper.

Output with `--help`:

```
Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                            [boolean]
```

Output with `--version`:

```
5.3.0
```
# Solution

Add [exitProcess(false)](https://github.com/yargs/yargs/blob/master/docs/api.md#exitprocessenable) so the process doesn't exit before loading the commands. In addition, `help` and `version` are also disable so they don't get printed when loading yargs.

`help` and `version` are enabled when loading the modules. 

Output with `--help`:

```
Sequelize CLI [Node: 10.13.0, CLI: 5.3.0, ORM: 4.41.0]

sequelize [command]

Commands:
  sequelize db:migrate                        Run pending migrations
  sequelize db:migrate:schema:timestamps:add  Update migration table to have timestamps
  sequelize db:migrate:status                 List the status of all migrations
  sequelize db:migrate:undo                   Reverts a migration
  sequelize db:migrate:undo:all               Revert all migrations ran
  sequelize db:seed                           Run specified seeder
  sequelize db:seed:undo                      Deletes data from the database
  sequelize db:seed:all                       Run every seeder
  sequelize db:seed:undo:all                  Deletes data from the database
  sequelize db:create                         Create database specified by configuration
  sequelize db:drop                           Drop database specified by configuration
  sequelize init                              Initializes project
  sequelize init:config                       Initializes configuration
  sequelize init:migrations                   Initializes migrations
  sequelize init:models                       Initializes models
  sequelize init:seeders                      Initializes seeders
  sequelize migration:generate                Generates a new migration file                                                       [aliases: migration:create]
  sequelize model:generate                    Generates a model and its migration                                                      [aliases: model:create]
  sequelize seed:generate                     Generates a new seed file                                                                 [aliases: seed:create]

Options:
  --help     Show help                                                                                                                               [boolean]
  --version  Show version number                                                                                                                     [boolean]
```

Output with `--version`:

```
Sequelize CLI [Node: 10.13.0, CLI: 5.3.0, ORM: 4.41.0]

5.3.0
```

## Other changes

- Since version 9.0, yargs are enabled by default, so it's not required to add help() to each command. See [yargs' changelog](https://github.com/yargs/yargs/blob/master/CHANGELOG.md#breaking-changes-3).