### PR TITLE
Bug Fix: Special characters in password are not escaped

### DIFF
--- a/src/helpers/config-helper.js
+++ b/src/helpers/config-helper.js
@@ -152,7 +152,7 @@ const api = {
   },
 
   filteredUrl (uri, config) {
-    const regExp = new RegExp(':?' + (config.password || '') + '@');
+    const regExp = new RegExp(':?' + _.escapeRegExp(config.password) + '@');
     return uri.replace(regExp, ':*****@');
   },
 


### PR DESCRIPTION
https://github.com/sequelize/cli/issues/172 is still happening when special characters find their way in a password