### PR TITLE
Fix `config.js` generation

### DIFF
--- a/src/helpers/config-helper.js
+++ b/src/helpers/config-helper.js
@@ -92,12 +92,15 @@ const api = {
 
   writeDefaultConfig () {
     const configPath = path.dirname(api.getConfigFile());
-
+    const configFilePath = api.getConfigFile();
+    const ext = configFilePath.split('.').pop();
+    const configContent = ext === 'json' ? api.getDefaultConfig() : `module.exports = ${ api.getDefaultConfig() }`;
+          
     if (!helpers.path.existsSync(configPath)) {
       helpers.asset.mkdirp(configPath);
     }
 
-    fs.writeFileSync(api.getConfigFile(), api.getDefaultConfig());
+    fs.writeFileSync(configFilePath, configContent);
   },
 
   readConfig () {

--- a/src/helpers/config-helper.js
+++ b/src/helpers/config-helper.js
@@ -94,8 +94,9 @@ const api = {
     const configPath = path.dirname(api.getConfigFile());
     const configFilePath = api.getConfigFile();
     const ext = configFilePath.split('.').pop();
-    const configContent = ext === 'json' ? api.getDefaultConfig() : `module.exports = ${ api.getDefaultConfig() }`;
-          
+    const defaultConfigContent = api.getDefaultConfig()
+    const configContent = ext === 'json' ? defaultConfigContent : `module.exports = ${ defaultConfigContent }`;
+    
     if (!helpers.path.existsSync(configPath)) {
       helpers.asset.mkdirp(configPath);
     }


### PR DESCRIPTION
If `.sequelizerc` has `config` file specified as '.js' file. Running `init` will generate invalid config file (with json content).

This patch fix this issue.