### PR TITLE
Add async to migration skeleton functions

### DIFF
--- a/src/assets/migrations/skeleton.js
+++ b/src/assets/migrations/skeleton.js
@@ -25,5 +25,5 @@ module.exports = {
       Or, await execution:
       queryInterface.dropTable('users');
     */
-  }
+  },
 };

--- a/src/assets/migrations/skeleton.js
+++ b/src/assets/migrations/skeleton.js
@@ -1,23 +1,29 @@
 'use strict';
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
+  up: async (queryInterface, Sequelize) => {
     /*
       Add altering commands here.
       Return a promise to correctly handle asynchronicity.
 
       Example:
       return queryInterface.createTable('users', { id: Sequelize.INTEGER });
+
+      Or, await execution:
+      await queryInterface.createTable('users', { id: Sequelize.INTEGER });
     */
   },
 
-  down: (queryInterface, Sequelize) => {
+  down: async (queryInterface, Sequelize) => {
     /*
       Add reverting commands here.
       Return a promise to correctly handle asynchronicity.
 
       Example:
       return queryInterface.dropTable('users');
+
+      Or, await execution:
+      queryInterface.dropTable('users');
     */
   }
 };

--- a/src/assets/migrations/skeleton.js
+++ b/src/assets/migrations/skeleton.js
@@ -23,7 +23,7 @@ module.exports = {
       return queryInterface.dropTable('users');
 
       Or, await execution:
-      queryInterface.dropTable('users');
+      await queryInterface.dropTable('users');
     */
   },
 };

--- a/test/migration/create.test.js
+++ b/test/migration/create.test.js
@@ -46,8 +46,8 @@ const gulp      = require('gulp');
           .src(Support.resolveSupportPath('tmp', 'migrations'))
           .pipe(helpers.readFile('*-' + migrationFile))
           .pipe(helpers.expect(stdout => {
-            expect(stdout).to.contain('up: (queryInterface, Sequelize) => {');
-            expect(stdout).to.contain('down: (queryInterface, Sequelize) => {');
+            expect(stdout).to.contain('up: async (queryInterface, Sequelize) => {');
+            expect(stdout).to.contain('down: async (queryInterface, Sequelize) => {');
           }))
           .pipe(helpers.teardown(done));
       });


### PR DESCRIPTION
This is a minor enhancement and would speed up workflow for those using `async/await`.

All tests passing, except for the following which seems unrelated to my changes:

```
290 passing (9m)
  1 failing

  1) [SQLITE] lib/sequelize model:create
       attributes
         --attributes first_name:string,last_name:string,bio:text,role:enum:{Admin,"Guest User"},reviews:array:text
           exits with exit code 0:
     Uncaught Error: Command failed: /Users/don/websites/js/sequelize/cli/lib/sequelize model:create --name User --attributes first_name:string,last_name:string,bio:text,role:enum:{Admin,"Guest User"},reviews:array:text
ERROR: Attribute 'role:enum:Admin' cannot be parsed: Unknown type 'Admin'

      at ChildProcess.exithandler (child_process.js:288:12)
      at ChildProcess.EventEmitter.emit (domain.js:442:20)
      at maybeClose (internal/child_process.js:962:16)
      at Process.ChildProcess._handle.onexit (internal/child_process.js:249:5)
```