### PR TITLE
Show original error details

### DIFF
--- a/src/helpers/view-helper.js
+++ b/src/helpers/view-helper.js
@@ -24,22 +24,22 @@ module.exports = {
 
   error (error) {
     let message = error;
-    let extraMessages = [];
+    const extraMessages = [];
 
     if (error instanceof Error) {
       message = !args.debug
         ? error.message
         : error.stack;
       if (error.original) {
-        extraMessages.push('Message: ' + error.original.message + '. Details: ' + error.original.detail)
+        extraMessages.push('Message: ' + error.original.message + '. Details: ' + error.original.detail);
       }
     }
 
     this.log();
     console.error(`${clc.red('ERROR:')} ${message}`);
-    extraMessages.forEach(message => {
-      console.error(message);
-    })
+    extraMessages.forEach(m => {
+      console.error(m);
+    });
     this.log();
 
     process.exit(1);

--- a/src/helpers/view-helper.js
+++ b/src/helpers/view-helper.js
@@ -24,15 +24,22 @@ module.exports = {
 
   error (error) {
     let message = error;
+    let extraMessages = [];
 
     if (error instanceof Error) {
       message = !args.debug
         ? error.message
         : error.stack;
+      if (error.original) {
+        extraMessages.push('Message: ' + error.original.message + '. Details: ' + error.original.detail)
+      }
     }
 
     this.log();
     console.error(`${clc.red('ERROR:')} ${message}`);
+    extraMessages.forEach(message => {
+      console.error(message);
+    })
     this.log();
 
     process.exit(1);


### PR DESCRIPTION
This patch is very useful for debugging errors which happens when you run db:migrate.
Error before (not so user-friendly):
```
ERROR: Validation error
```
Error after (much easier to find what causes it, right?):
```
ERROR: Validation error
Message: could not create unique index "unique_slug". Details: Key (slug)=(dota2-pro-league-1-open-qualifiers) is duplicated.
```