### PR TITLE
Recover from errors when running migrations in a non-default schema with a user who cannot create schemas

### DIFF
--- a/src/core/migrator.js
+++ b/src/core/migrator.js
@@ -34,7 +34,7 @@ function getSequelizeInstance () {
 function createSchemaIfNotExists(sequelize, schemaName) {
   return sequelize.showAllSchemas().then(
     schemaNames => {
-      if(schemaNames.indexOf(schemaName === -1)) {
+      if(schemaNames.indexOf(schemaName) === -1) {
         return sequelize.createSchema(schemaName);
       }
       return;

--- a/src/core/migrator.js
+++ b/src/core/migrator.js
@@ -67,7 +67,14 @@ export function getMigrator (type, args) {
         if (helpers.version.getDialectName() === 'pg') {
           const customSchemaName = helpers.umzug.getSchema('migration');
           if (customSchemaName && customSchemaName !== 'public') {
-            return sequelize.createSchema(customSchemaName);
+            return sequelize.createSchema(customSchemaName).catch((err) => {
+              helpers.view.log(
+                `Failed attempting to create schema named`,
+                clc.blueBright(customSchemaName),
+                `: ${err.message}
+Migration may still succeed if the schema already exists.`
+                );
+            });
           }
         }
 

--- a/src/core/migrator.js
+++ b/src/core/migrator.js
@@ -1,3 +1,4 @@
+import clc from 'cli-color';
 import Umzug from 'umzug';
 import Bluebird from 'bluebird';
 import _ from 'lodash';
@@ -67,13 +68,12 @@ export function getMigrator (type, args) {
         if (helpers.version.getDialectName() === 'pg') {
           const customSchemaName = helpers.umzug.getSchema('migration');
           if (customSchemaName && customSchemaName !== 'public') {
-            return sequelize.createSchema(customSchemaName).catch((err) => {
+            return sequelize.createSchema(customSchemaName).catch(err => {
               helpers.view.log(
-                `Failed attempting to create schema named`,
+                'Failed attempting to create schema named',
                 clc.blueBright(customSchemaName),
-                `: ${err.message}
-Migration may still succeed if the schema already exists.`
-                );
+                ': ' + err.message + '\nMigration may still succeed if the schema already exists.'
+              );
             });
           }
         }

--- a/src/core/migrator.js
+++ b/src/core/migrator.js
@@ -31,6 +31,17 @@ function getSequelizeInstance () {
   }
 }
 
+function createSchemaIfNotExists(sequelize, schemaName) {
+  return sequelize.showAllSchemas().then(
+    schemaNames => {
+      if(schemaNames.indexOf(schemaName === -1)) {
+        return sequelize.createSchema(schemaName);
+      }
+      return;
+    }
+  );
+}
+
 export function getMigrator (type, args) {
   return Bluebird.try(() => {
     if (!(helpers.config.configFileExists() || args.url)) {
@@ -67,12 +78,12 @@ export function getMigrator (type, args) {
         // been created. If not, attempt to create it.
         if (helpers.version.getDialectName() === 'pg') {
           const customSchemaName = helpers.umzug.getSchema('migration');
-          if (customSchemaName && customSchemaName !== 'public') {
-            return sequelize.createSchema(customSchemaName).catch(err => {
+          if (customSchemaName && customSchemaName !== 'public' ) {
+            return createSchemaIfNotExists(sequelize, customSchemaName).catch(err => {
               helpers.view.log(
                 'Failed attempting to create schema named',
                 clc.blueBright(customSchemaName),
-                ': ' + err.message + '\nMigration may still succeed if the schema already exists.'
+                ': ' + err.message
               );
             });
           }


### PR DESCRIPTION
My team encountered this and had to revert to an older version of sequelize-cli in order to keep moving forward.

Our migrations are run as a user that does not have permissions to create new schemas, but has full access to the custom schema passed in. When sequelize-cli started attempting to create the custom schema every time, without checking if the schema exists, we started seeing migrations fail with `ERROR: permission denied for database`. This will give the user some information about what's happening, while letting us move to current sequelize-cli.