### PR TITLE
Added my fix to the Unable to resolve sequelize package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Now you can run CLI using following command anywhere
 $ sequelize
 ```
 
+If after you run `sequelize` and you get an error similar to:
+```bash
+Unable to resolve sequelize package in ....
+```
+You will need to install sequelize globally.
+```bash
+npm install -g sequelize
+```
+
+
 ### Locally
 Install CLI locally to your `node_modules` folder with
 


### PR DESCRIPTION
I ran into an issue with installing the CLI in which it gave me a message:
```
Unable to resolve sequelize package from ...
```
It noticed that the sequelize package also needed to be installed for the CLI to work correctly.

I figured I would contribute and save some people some time.