### PR TITLE
propagating ssl=true from --url into dialectOptions

### DIFF
--- a/src/helpers/config-helper.js
+++ b/src/helpers/config-helper.js
@@ -187,7 +187,10 @@ const api = {
     let config = api.urlStringToConfigHash(urlString);
 
     config = _.assign(config, {
-      dialect: config.protocol
+      dialect: config.protocol,
+      dialectOptions: {
+        ssl: config.ssl
+      }
     });
 
     if (config.dialect === 'sqlite' && config.database.indexOf(':memory') !== 0) {


### PR DESCRIPTION
When connecting to the database using the `--url` option I noticed the ssl options are ignored. The only option being to revert to a config file specifying `dialectOptions` directly there.

While it worked just fine it felt too cumbersome to manage when the rest of the app configuration is made via env variables.

Digging a little bit into the code turns out the url parser fully supports the `ssl=true` option yet doesn't propagates it further into the `config` object to have a Sequelize instance initialised.

This small change addresses the issue.

Fixes https://github.com/sequelize/cli/issues/154