### PR TITLE
Added sequelize-cli as an alias for the binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "5.5.0",
   "description": "The Sequelize CLI",
   "bin": {
-    "sequelize": "./lib/sequelize"
+    "sequelize": "./lib/sequelize",
+    "sequelize-cli": "./lib/sequelize"
   },
   "dependencies": {
     "bluebird": "^3.5.3",


### PR DESCRIPTION
The binary is currently called sequelize, but references in documentation say it is sequelize-cli

The result is npx always ends up trying to download sequelize-cli from npm. This is because npx looks for the command in the path and then checks npm if it fails to find it. To show this, run `npx --no-install sequelize-cli --help` which will prevent npx from falling back to downloading the package from npm. This command should fail without this change.

This should greatly increase performance for people following the docs as well as prevent issues such as #803 .

Rather than delete the existing binary name of sequelize, I figured it was best to add sequelize-cli as a secondary name in case other people had figured this out and rely on using the name sequelize in scripts or commands (and the main package doesn't add anything to the bin folder).