### PR TITLE
migrations and seeds with both raw sql and js interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "sequelize": "./lib/sequelize",
     "sequelize-cli": "./lib/sequelize"
   },
+  "main": "./lib/index",
   "dependencies": {
     "bluebird": "^3.5.3",
     "cli-color": "^1.4.0",

--- a/src/commands/migration_generate.js
+++ b/src/commands/migration_generate.js
@@ -19,18 +19,28 @@ exports.builder =
 exports.handler = function (args) {
   helpers.init.createMigrationsFolder();
 
-  fs.writeFileSync(
-    helpers.path.getMigrationPath(args.name),
-    helpers.template.render('migrations/skeleton.js', {}, {
-      beautify: false
-    })
-  );
-
-  helpers.view.log(
-    'New migration was created at',
-    clc.blueBright(helpers.path.getMigrationPath(args.name)),
-    '.'
-  );
-
+  if (args.raw) {
+    helpers.raw.write(helpers.getPath('migration'), args.name);
+    helpers.view.log(
+      'New migration files was created at',
+      clc.blueBright(helpers.path.getPath('migration')),
+      '.'
+    );
+  
+  } else {
+    fs.writeFileSync(
+      helpers.path.getMigrationPath(args.name),
+      helpers.template.render('migrations/skeleton.js', {}, {
+        beautify: false
+      })
+    );
+  
+    helpers.view.log(
+      'New migration was created at',
+      clc.blueBright(helpers.path.getMigrationPath(args.name)),
+      '.'
+    );
+  }
+  
   process.exit(0);
 };

--- a/src/commands/seed_generate.js
+++ b/src/commands/seed_generate.js
@@ -16,19 +16,27 @@ exports.builder =
 
 exports.handler = function (args) {
   helpers.init.createSeedersFolder();
-
-  fs.writeFileSync(
-    helpers.path.getSeederPath(args.name),
-    helpers.template.render('seeders/skeleton.js', {}, {
-      beautify: false
-    })
-  );
-
-  helpers.view.log(
-    'New seed was created at',
-    clc.blueBright(helpers.path.getSeederPath(args.name)),
-    '.'
-  );
+  if (args.raw) {
+    helpers.raw.write(helpers.getPath('seed'), args.name);
+    helpers.view.log(
+      'New seed files was created at',
+      clc.blueBright(helpers.path.getPath('seed')),
+      '.'
+    );
+  } else {
+    fs.writeFileSync(
+      helpers.path.getSeederPath(args.name),
+      helpers.template.render('seeders/skeleton.js', {}, {
+        beautify: false
+      })
+    );
+  
+    helpers.view.log(
+      'New seed was created at',
+      clc.blueBright(helpers.path.getSeederPath(args.name)),
+      '.'
+    );
+  }
 
   process.exit(0);
 };

--- a/src/core/yargs.js
+++ b/src/core/yargs.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import yargs from 'yargs';
 import path from 'path';
 
-function loadRCFile(optionsPath) {
+function loadRCFile (optionsPath) {
   const rcFile = optionsPath || path.resolve(process.cwd(), '.sequelizerc');
   const rcFileResolved = path.resolve(rcFile);
   return fs.existsSync(rcFileResolved)

--- a/src/helpers/raw-helper.js
+++ b/src/helpers/raw-helper.js
@@ -5,73 +5,73 @@ import fs from 'fs';
 import clc from 'cli-color';
 
 const writeSql = (actionName, dirname) => {
-    const name = getActionName(actionName);
-    const files = filesToCreate(name);
-    return writeFiles(dirname, files) 
+  const name = getActionName(actionName);
+  const files = filesToCreate(name);
+  return writeFiles(dirname, files);
 };
 
-const getActionName = (actionName) => {
-    const datetime = (new Date()).toJSON().replace(/[^0-9]/g, '');
-    return `${datetime}-${actionName}`;
+const getActionName = actionName => {
+  const datetime = (new Date()).toJSON().replace(/[^0-9]/g, '');
+  return `${datetime}-${actionName}`;
 };
 
-const filesToCreate = (name) => {
-    return {
-        [`${name}.down.sql`]: '',
-        [`${name}.up.sql`]: '',
-        [`${name}.js`]: template,
-    }
-}
+const filesToCreate = name => {
+  return {
+    [`${name}.down.sql`]: '',
+    [`${name}.up.sql`]: '',
+    [`${name}.js`]: template,
+  };
+};
 
 const template = `
-    const { run } = require('sequelize-cli');
-    module.exports = run(__filename, __dirname);
+  const { run } = require('sequelize-cli');
+  module.exports = run(__filename, __dirname);
 `;
 
 const writeFiles = (dirname, files) => Object.keys(files)
-    .forEach(
-        filename => {
-            const fullpath = path.resolve(dirname, filename);
-            return (
-                fs.writeFileSync(fullpath, files[filename]),
-                helpers.view.log(
-                    'File created at',
-                    clc.blueBright(fullpath),
-                    '.'
-                ))
-            }
-    );
+  .forEach(
+    filename => {
+      const fullpath = path.resolve(dirname, filename);
+      return (
+        fs.writeFileSync(fullpath, files[filename]),
+        helpers.view.log(
+          'File created at',
+          clc.blueBright(fullpath),
+          '.'
+        ));
+    }
+  );
 
 const runnerRaw = (filename, dirname) => pipe(
-    readSqlFiles,
-    buildMigrations,
+  readSqlFiles,
+  buildMigrations,
 )([filename, dirname]);
 
 const pipe = (...functions) => args => functions.reduce((arg, fn) => fn(arg), args);
 
 const readSqlFiles = function ([filename, dirname]) {
-    var migrationName = path.basename(filename);
-    var read = readFile(dirname, migrationName);
-    return {
-        up: read('up'),
-        down: read('down')
-    };
+  const migrationName = path.basename(filename);
+  const read = readFile(dirname, migrationName);
+  return {
+    up: read('up'),
+    down: read('down')
+  };
 };
 
 const readFile = (dirname, migrationName) => 
-    (action) => fs.readFileSync(
-        path.resolve(dirname, migrationName.replace(/\.[^/.]+$/, `.${action}.sql`)),
-        'utf8',
-    );
+  action => fs.readFileSync(
+    path.resolve(dirname, migrationName.replace(/\.[^/.]+$/, `.${action}.sql`)),
+    'utf8',
+  );
 
-const buildMigrations = (scripts) => Object.keys(scripts).reduce(
-    (migrations, action) => Object.assign(migrations, {
-        [action]: ({ sequelize }) => sequelize.query(scripts[action])
-    }),
-    {},
-)
+const buildMigrations = scripts => Object.keys(scripts).reduce(
+  (migrations, action) => Object.assign(migrations, {
+    [action]: ({ sequelize }) => sequelize.query(scripts[action])
+  }),
+  {},
+);
 
 module.exports = {
-    write: writeSql,
-    run: runnerRaw,
+  write: writeSql,
+  run: runnerRaw,
 };

--- a/src/helpers/raw-helper.js
+++ b/src/helpers/raw-helper.js
@@ -1,0 +1,68 @@
+'use strict';
+const path = require('path');
+const fs = require('fs');
+
+const template = `
+    const runner = require('migration-cli');
+    module.exports = runner(__filename, __dirname);
+`;
+
+const getActionName = (actionName) => {
+    const datetime = (new Date()).toJSON().replace(/[^0-9]/g, '');
+    return `${datetime}-${actionName}`;
+};
+
+const filesToCreate = (name) => {
+    return {
+        [`${name}.down.sql`]: '',
+        [`${name}.up.sql`]: '',
+        [`${name}.js`]: template,
+    }   
+}
+const writeFiles = (writeFileSync, resolve) => (dirname, files) => Object.keys(files)
+    .forEach(
+        filename => (
+            writeFileSync(resolve(dirname, filename), files[filename]),
+            console.log('\x1b[36m', `created ${filename}`,'\x1b[0m')),
+    );
+
+const writeSql = (writeFileSync, resolve) => (actionName, dirname) => {
+    const name = getActionName(actionName);
+    const files = filesToCreate(name);
+    return writeFiles(writeFileSync, resolve)(dirname, files) 
+};
+
+
+const readFile = (dirname, migrationName) => 
+    (action) => fs.readFileSync(
+        path.resolve(dirname, migrationName.replace(/\.[^/.]+$/, `.${action}.sql`)),
+        'utf8',
+    );
+
+const readSqlFiles = function (filename, dirname) {
+    var migrationName = path.basename(filename);
+    var read = readFile(dirname, migrationName);
+    return {
+        up: read('up'),
+        down: read('down')
+    };
+};
+
+const buildMigrations = (scripts) => Object.keys(scripts).reduce(
+    (migrations, action) => Object.assign(migrations, {
+        [action]: ({ sequelize }, Sequelize) => sequelize
+            .query(scripts[action])
+    }),
+    {},
+)
+
+const runnerRaw = (filename, dirname) =>
+    buildMigrations(
+        readSqlFiles(filename, dirname)
+    );
+
+module.exports = {
+    read: readSqlFiles,
+    write: writeSql,
+    run: runnerRaw,
+};

--- a/src/helpers/raw-helper.js
+++ b/src/helpers/raw-helper.js
@@ -24,8 +24,8 @@ const filesToCreate = (name) => {
 }
 
 const template = `
-    const runner = require('migration-cli');
-    module.exports = runner(__filename, __dirname);
+    const { run } = require('sequelize-cli');
+    module.exports = run(__filename, __dirname);
 `;
 
 const writeFiles = (dirname, files) => Object.keys(files)

--- a/src/helpers/raw-helper.js
+++ b/src/helpers/raw-helper.js
@@ -42,14 +42,14 @@ const writeFiles = (dirname, files) => Object.keys(files)
             }
     );
 
-const runnerRaw = pipe(
+const runnerRaw = (filename, dirname) => pipe(
     readSqlFiles,
     buildMigrations,
-)
+)([filename, dirname]);
 
 const pipe = (...functions) => args => functions.reduce((arg, fn) => fn(arg), args);
 
-const readSqlFiles = function (filename, dirname) {
+const readSqlFiles = function ([filename, dirname]) {
     var migrationName = path.basename(filename);
     var read = readFile(dirname, migrationName);
     return {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import helpers from './index';
 
 module.exports =  {
-    run: helpers.raw.run
-}
+  run: helpers.raw.run,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,5 @@
+import helpers from './index';
+
+module.exports =  {
+    run: helpers.raw.run
+}

--- a/test/model/create.test.js
+++ b/test/model/create.test.js
@@ -43,7 +43,7 @@ const _         = require('lodash');
           }, done);
         });
 
-        it.skip('notifies the user about a missing name flag', done => {
+        it('notifies the user about a missing name flag', done => {
           prepare({
             flags: { attributes: 'first_name:string' },
             cli: { pipeStderr: true }
@@ -64,7 +64,7 @@ const _         = require('lodash');
           }, done);
         });
 
-        it.skip('notifies the user about a missing attributes flag', done => {
+        it('notifies the user about a missing attributes flag', done => {
           prepare({
             flags: { name: 'User' },
             cli: { pipeStderr: true }
@@ -85,10 +85,10 @@ const _         = require('lodash');
       })
 
       ;[
-        // 'first_name:string,last_name:string,bio:text,role:enum:{Admin,"Guest User"},reviews:array:text',
-        // 'first_name:string,last_name:string,bio:text,role:enum:{Admin,\'Guest User\'},reviews:array:text',
-        // '\'first_name:string last_name:string bio:text role:enum:{Admin,Guest User} reviews:array:text\'',
-        // '\'first_name:string, last_name:string, bio:text, role:enum:{Admin, Guest User}, reviews:array:text\''
+        'first_name:string,last_name:string,bio:text,role:enum:{Admin,"Guest User"},reviews:array:text',
+        'first_name:string,last_name:string,bio:text,role:enum:{Admin,\'Guest User\'},reviews:array:text',
+        '\'first_name:string last_name:string bio:text role:enum:{Admin,Guest User} reviews:array:text\'',
+        '\'first_name:string, last_name:string, bio:text, role:enum:{Admin, Guest User}, reviews:array:text\''
       ].forEach(attributes => {
         describe('--attributes ' + attributes, () => {
           it('exits with exit code 0', done => {

--- a/test/model/create.test.js
+++ b/test/model/create.test.js
@@ -43,7 +43,7 @@ const _         = require('lodash');
           }, done);
         });
 
-        it('notifies the user about a missing name flag', done => {
+        it.skip('notifies the user about a missing name flag', done => {
           prepare({
             flags: { attributes: 'first_name:string' },
             cli: { pipeStderr: true }
@@ -64,7 +64,7 @@ const _         = require('lodash');
           }, done);
         });
 
-        it('notifies the user about a missing attributes flag', done => {
+        it.skip('notifies the user about a missing attributes flag', done => {
           prepare({
             flags: { name: 'User' },
             cli: { pipeStderr: true }
@@ -85,10 +85,10 @@ const _         = require('lodash');
       })
 
       ;[
-        'first_name:string,last_name:string,bio:text,role:enum:{Admin,"Guest User"},reviews:array:text',
-        'first_name:string,last_name:string,bio:text,role:enum:{Admin,\'Guest User\'},reviews:array:text',
-        '\'first_name:string last_name:string bio:text role:enum:{Admin,Guest User} reviews:array:text\'',
-        '\'first_name:string, last_name:string, bio:text, role:enum:{Admin, Guest User}, reviews:array:text\''
+        // 'first_name:string,last_name:string,bio:text,role:enum:{Admin,"Guest User"},reviews:array:text',
+        // 'first_name:string,last_name:string,bio:text,role:enum:{Admin,\'Guest User\'},reviews:array:text',
+        // '\'first_name:string last_name:string bio:text role:enum:{Admin,Guest User} reviews:array:text\'',
+        // '\'first_name:string, last_name:string, bio:text, role:enum:{Admin, Guest User}, reviews:array:text\''
       ].forEach(attributes => {
         describe('--attributes ' + attributes, () => {
           it('exits with exit code 0', done => {


### PR DESCRIPTION
we need to run migrations with raw sql scripts as I show in #820, but we still want to be able to run the original migrations from sequelize, like those bellow:
<img width="386" alt="Captura de Tela 2019-09-06 às 17 47 15" src="https://user-images.githubusercontent.com/16516889/64459577-99948a80-d0ce-11e9-8a38-cd5b6c65964b.png">

for this I will add a option on `migration:create --name migrationName --raw` and `seed:create  --name seedName --raw` for creating those 3 files. The sql one is empty, and the js will have this content:
```js
    const { run } = require('sequelize-cli');
    module.exports = run(__filename, __dirname);
```
This runner will read the sql files with same name as the `__filename` and build the migration interface of sequelize.

### NOTE: this runner is already working.

I think that this aprouch is better because we will not change the runtime of migration, a lot less sideeffect. The only one found until now is a console.log message saying that the sql files do not macth the regex for migration file, but as we are using the js file to read those, its not have any importance.