### PR TITLE
Add support of file extensions for .sequelizerc config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ test/support/tmp/*
 package-lock.json
 yarn.lock
 npm-debug.log
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "bluebird": "^3.5.3",
     "cli-color": "^1.4.0",
+    "cosmiconfig": "^5.2.1",
     "fs-extra": "^7.0.1",
     "js-beautify": "^1.8.8",
     "lodash": "^4.17.5",

--- a/src/core/yargs.js
+++ b/src/core/yargs.js
@@ -1,13 +1,13 @@
-import fs from 'fs';
 import yargs from 'yargs';
 import path from 'path';
+import cosmiconfig from 'cosmiconfig';
 
-function loadRCFile(optionsPath) {
-  const rcFile = optionsPath || path.resolve(process.cwd(), '.sequelizerc');
-  const rcFileResolved = path.resolve(rcFile);
-  return fs.existsSync(rcFileResolved)
-    ? JSON.parse(JSON.stringify(require(rcFileResolved)))
-    : {};
+const explorer = cosmiconfig('sequelize', {stopDir: process.cwd()});
+
+function loadRCFile (optionsPath) {
+  optionsPath = path.resolve(optionsPath || process.cwd());
+
+  return explorer.searchSync(optionsPath).config;
 }
 
 const args = yargs

--- a/src/core/yargs.js
+++ b/src/core/yargs.js
@@ -2,7 +2,20 @@ import yargs from 'yargs';
 import path from 'path';
 import cosmiconfig from 'cosmiconfig';
 
-const explorer = cosmiconfig('sequelize', {stopDir: process.cwd()});
+function noExtLoader (filename, content) {
+  try {
+    return JSON.parse(content);
+  } catch (_) {
+    return require(filename);
+  }
+}
+
+const explorer = cosmiconfig('sequelize', {
+  stopDir: process.cwd(),
+  loaders: {
+    noExt: noExtLoader
+  }
+});
 
 function loadRCFile (optionsPath) {
   optionsPath = path.resolve(optionsPath || process.cwd());

--- a/src/core/yargs.js
+++ b/src/core/yargs.js
@@ -7,7 +7,9 @@ const explorer = cosmiconfig('sequelize', {stopDir: process.cwd()});
 function loadRCFile (optionsPath) {
   optionsPath = path.resolve(optionsPath || process.cwd());
 
-  return explorer.searchSync(optionsPath).config;
+  const file = explorer.searchSync(optionsPath);
+
+  return file ? file.config : {};
 }
 
 const args = yargs

--- a/src/core/yargs.js
+++ b/src/core/yargs.js
@@ -4,7 +4,7 @@ import cosmiconfig from 'cosmiconfig';
 
 function noExtLoader (filename, content) {
   try {
-    return JSON.parse(content);
+    return cosmiconfig.loadJson(filename, content);
   } catch (_) {
     return require(filename);
   }

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -83,7 +83,7 @@ describe(Support.getTestDialectTeaser('options'), () => {
       gulp
         .src(Support.resolveSupportPath('tmp'))
         .pipe(helpers.clearDirectory())
-        .pipe(helpers.copyFile(optionsPath, '.sequelizerc'))
+        .pipe(helpers.copyFile(optionsPath, '.sequelizerc.js'))
         .pipe(helpers.runCli('init --config=' + configPath))
         .pipe(helpers.listFiles())
         .pipe(helpers.ensureContent('models'))

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -76,7 +76,7 @@ describe(Support.getTestDialectTeaser('options'), () => {
       gulp
         .src(Support.resolveSupportPath('tmp'))
         .pipe(helpers.clearDirectory())
-        .pipe(helpers.copyFile(optionsPath, '.sequelizerc.js'))
+        .pipe(helpers.copyFile(optionsPath, '.sequelizerc'))
         .pipe(helpers.runCli('init --config=' + configPath))
         .pipe(helpers.listFiles())
         .pipe(helpers.ensureContent('models'))

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -44,32 +44,6 @@ describe(Support.getTestDialectTeaser('options'), () => {
         .pipe(helpers.teardown(done));
     });
 
-    it('uses .sequelizerc.js file', done => {
-      gulp
-        .src(Support.resolveSupportPath('tmp'))
-        .pipe(helpers.clearDirectory())
-        .pipe(helpers.copyFile(optionsPath, '.sequelizerc.js'))
-        .pipe(helpers.overwriteFile(configContent, '.sequelizerc.js'))
-        .pipe(helpers.runCli('init'))
-        .pipe(helpers.listFiles())
-        .pipe(helpers.ensureContent('migrations-new'))
-        .pipe(helpers.ensureContent('config-new'))
-        .pipe(helpers.teardown(done));
-    });
-
-    it('uses sequelize.config.js file', done => {
-      gulp
-        .src(Support.resolveSupportPath('tmp'))
-        .pipe(helpers.clearDirectory())
-        .pipe(helpers.copyFile(optionsPath, 'sequelize.config.js'))
-        .pipe(helpers.overwriteFile(configContent, 'sequelize.config.js'))
-        .pipe(helpers.runCli('init'))
-        .pipe(helpers.listFiles())
-        .pipe(helpers.ensureContent('migrations-new'))
-        .pipe(helpers.ensureContent('config-new'))
-        .pipe(helpers.teardown(done));
-    });
-
     it('prefers CLI arguments over .sequelizerc file', done => {
       const configPath = Support.resolveSupportPath('tmp', 'config', 'config.js');
 

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -32,18 +32,11 @@ describe(Support.getTestDialectTeaser('options'), () => {
     `;
 
     it('uses .sequelizerc file', done => {
-      const content = `
-        {
-          "config": "config-new/database.json",
-          "migrations-path": "migrations-new"
-        }
-      `;
-
       gulp
         .src(Support.resolveSupportPath('tmp'))
         .pipe(helpers.clearDirectory())
         .pipe(helpers.copyFile(optionsPath, '.sequelizerc'))
-        .pipe(helpers.overwriteFile(content, '.sequelizerc'))
+        .pipe(helpers.overwriteFile(configContent, '.sequelizerc'))
         .pipe(helpers.runCli('init'))
         .pipe(helpers.listFiles())
         .pipe(helpers.ensureContent('migrations-new'))

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -32,11 +32,18 @@ describe(Support.getTestDialectTeaser('options'), () => {
     `;
 
     it('uses .sequelizerc file', done => {
+      const content = `
+        {
+          "config": "config-new/database.json",
+          "migrations-path": "migrations-new"
+        }
+      `;
+
       gulp
         .src(Support.resolveSupportPath('tmp'))
         .pipe(helpers.clearDirectory())
         .pipe(helpers.copyFile(optionsPath, '.sequelizerc'))
-        .pipe(helpers.overwriteFile(configContent, '.sequelizerc'))
+        .pipe(helpers.overwriteFile(content, '.sequelizerc'))
         .pipe(helpers.runCli('init'))
         .pipe(helpers.listFiles())
         .pipe(helpers.ensureContent('migrations-new'))

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -22,21 +22,47 @@ describe(Support.getTestDialectTeaser('options'), () => {
   });
 
   describe('.sequelizerc', () => {
+    const configContent = `
+      var path = require('path');
+
+      module.exports = {
+        'config':          path.resolve('config-new', 'database.json'),
+        'migrations-path': path.resolve('migrations-new')
+      };
+    `;
+
     it('uses .sequelizerc file', done => {
-      const configContent = `
-        var path = require('path');
-
-        module.exports = {
-          'config':          path.resolve('config-new', 'database.json'),
-          'migrations-path': path.resolve('migrations-new')
-        };
-      `;
-
       gulp
         .src(Support.resolveSupportPath('tmp'))
         .pipe(helpers.clearDirectory())
         .pipe(helpers.copyFile(optionsPath, '.sequelizerc'))
         .pipe(helpers.overwriteFile(configContent, '.sequelizerc'))
+        .pipe(helpers.runCli('init'))
+        .pipe(helpers.listFiles())
+        .pipe(helpers.ensureContent('migrations-new'))
+        .pipe(helpers.ensureContent('config-new'))
+        .pipe(helpers.teardown(done));
+    });
+
+    it('uses .sequelizerc.js file', done => {
+      gulp
+        .src(Support.resolveSupportPath('tmp'))
+        .pipe(helpers.clearDirectory())
+        .pipe(helpers.copyFile(optionsPath, '.sequelizerc.js'))
+        .pipe(helpers.overwriteFile(configContent, '.sequelizerc.js'))
+        .pipe(helpers.runCli('init'))
+        .pipe(helpers.listFiles())
+        .pipe(helpers.ensureContent('migrations-new'))
+        .pipe(helpers.ensureContent('config-new'))
+        .pipe(helpers.teardown(done));
+    });
+
+    it('uses sequelize.config.js file', done => {
+      gulp
+        .src(Support.resolveSupportPath('tmp'))
+        .pipe(helpers.clearDirectory())
+        .pipe(helpers.copyFile(optionsPath, 'sequelize.config.js'))
+        .pipe(helpers.overwriteFile(configContent, 'sequelize.config.js'))
         .pipe(helpers.runCli('init'))
         .pipe(helpers.listFiles())
         .pipe(helpers.ensureContent('migrations-new'))


### PR DESCRIPTION
This pull request improves .sequelizerc config loading by adding an ability to use extensions in the name. Now CLI will use [`cosmiconfig`](https://github.com/davidtheclark/cosmiconfig), so it will try load config from (according to cosmiconfig documentation):
- a `sequelize` property from package.json file
- `.sequelizerc` file
- `.sequelizerc.json` file
- `.sequelizerc.yml`, `.sequelizerc.yaml` or `.sequelizerc.js` files
- `sequelize.config.js` file

Since I have an obstacle with tests, I have decided to open this pull request to get your help with that.
Tests failing with the following message, so I can't be sure if everything is okay and the new feature passes:
<details>
<summary>Failing tests</summary>

<img width="1104" alt="iTerm2_2019-09-12 02-29-48@2x" src="https://user-images.githubusercontent.com/7884558/64742574-5dfe2400-d505-11e9-920e-cb6e4c0254c1.png">


</details>

I'm using Node 12.9.1, Yarn 1.17.3 and macOS 10.14.6 to run tests.
