### PR TITLE
add filename-date-format flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## Future
 
+### Feature
+- feat(mode:generate) add `--filename-date-format` flag [#850](https://github.com/sequelize/cli/pull/850)
+
 ## v5.5.1 - 31st, August 2019
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-cli",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "description": "The Sequelize CLI",
   "bin": {
     "sequelize": "./lib/sequelize",

--- a/src/commands/migration_generate.js
+++ b/src/commands/migration_generate.js
@@ -13,6 +13,12 @@ exports.builder =
           type: 'string',
           demandOption: true
         })
+        .option('filename-date-format', {
+          describe: 'Defines the type of date format used in the file name',
+          type: 'string',
+          choices: ['dateYYYYMMDDHHmms', 'unix-timestamp', 'unix-timestamp-millis'],
+          demandOption: false
+        })
     )
       .argv;
 
@@ -20,7 +26,7 @@ exports.handler = function (args) {
   helpers.init.createMigrationsFolder();
 
   fs.writeFileSync(
-    helpers.path.getMigrationPath(args.name),
+    helpers.path.getMigrationPath(args),
     helpers.template.render('migrations/skeleton.js', {}, {
       beautify: false
     })

--- a/src/helpers/path-helper.js
+++ b/src/helpers/path-helper.js
@@ -22,6 +22,27 @@ function getCurrentYYYYMMDDHHmms () {
   ].join('');
 }
 
+function getUnixTimestampMillis () {
+  return Date.now();
+}
+
+function getUnixTimestamp () {
+  return Math.round(Date.now() / 1000);
+}
+
+function getFormattedDate (timestampOption) {
+  switch (timestampOption) {
+    case 'dateYYYYMMDDHHmms':
+      return getCurrentYYYYMMDDHHmms();
+    case 'unix-timestamp':
+      return getUnixTimestamp();
+    case 'unix-timestamp-millis':
+      return getUnixTimestampMillis ();
+    default:
+      return getCurrentYYYYMMDDHHmms();
+  }
+}
+
 module.exports = {
   getPath (type) {
     type = type + 's';
@@ -36,11 +57,11 @@ module.exports = {
     return result;
   },
 
-  getFileName (type, name, options) {
+  getFileName (type, options) {
     return this.addFileExtension(
       [
-        getCurrentYYYYMMDDHHmms(),
-        name ? name : 'unnamed-' + type
+        getFormattedDate(options.filenameDateFormat),
+        options.name ? options.name : 'unnamed-' + type
       ].join('-'),
       options
     );
@@ -54,8 +75,8 @@ module.exports = {
     return [basename, this.getFileExtension(options)].join('.');
   },
 
-  getMigrationPath (migrationName) {
-    return path.resolve(this.getPath('migration'), this.getFileName('migration', migrationName));
+  getMigrationPath (options) {
+    return path.resolve(this.getPath('migration'), this.getFileName('migration', options));
   },
 
   getSeederPath (seederName) {

--- a/test/migration/create.test.js
+++ b/test/migration/create.test.js
@@ -2,35 +2,47 @@ const expect    = require('expect.js');
 const Support   = require(__dirname + '/../support');
 const helpers   = require(__dirname + '/../support/helpers');
 const gulp      = require('gulp');
+const _         = require('lodash');
+
+const getDateStrYYYYMMDDHHmm = () => {
+  const date        = new Date();
+  const format      = function (i) {
+    return parseInt(i, 10) < 10 ? '0' + i : i;
+  };
+  return [
+    date.getUTCFullYear(),
+    format(date.getUTCMonth() + 1),
+    format(date.getUTCDate()),
+    format(date.getUTCHours()),
+    format(date.getUTCMinutes())
+  ].join('');
+};
 
 [
   'migration:create'
 ].forEach(flag => {
   describe(Support.getTestDialectTeaser(flag), () => {
     const migrationFile = 'foo.js';
-    const prepare = function (callback) {
+    const flags = {
+      name: 'foo'
+    };
+    const prepare = function (options, callback) {
+      options = _.assign({
+        flags: {},
+        cli:   { pipeStdout: true }
+      }, options || {});
+
       gulp
         .src(Support.resolveSupportPath('tmp'))
         .pipe(helpers.clearDirectory())
         .pipe(helpers.runCli('init'))
-        .pipe(helpers.runCli(flag + ' --name=foo'))
+        .pipe(helpers.runCli(helpers.buildCommand(flag, options.flags), options.cli))
         .pipe(helpers.teardown(callback));
     };
 
     it('creates a new file with the current timestamp', done => {
-      prepare(() => {
-        const date        = new Date();
-        const format      = function (i) {
-          return parseInt(i, 10) < 10 ? '0' + i : i;
-        };
-        const sDate       = [
-          date.getUTCFullYear(),
-          format(date.getUTCMonth() + 1),
-          format(date.getUTCDate()),
-          format(date.getUTCHours()),
-          format(date.getUTCMinutes())
-        ].join('');
-        const expectation = new RegExp(sDate + '..-' + migrationFile);
+      prepare({ flags }, () => {
+        const expectation = new RegExp(getDateStrYYYYMMDDHHmm() + '\\d{2}-' + migrationFile);
 
         gulp
           .src(Support.resolveSupportPath('tmp', 'migrations'))
@@ -40,8 +52,74 @@ const gulp      = require('gulp');
       });
     });
 
+    describe('--filename-date-format flag', () => {
+      it('creates a new file with the YYYYMMDDHHmms date format', done => {
+        prepare({
+          flags: _.assign({
+            'filename-date-format': 'dateYYYYMMDDHHmms'
+          }, flags)
+        }, () => {
+          const expectation = new RegExp(getDateStrYYYYMMDDHHmm() + '\\d{2}-' + migrationFile);
+
+          gulp
+            .src(Support.resolveSupportPath('tmp', 'migrations'))
+            .pipe(helpers.listFiles())
+            .pipe(helpers.ensureContent(expectation))
+            .pipe(helpers.teardown(done));
+        });
+      });
+
+      it('creates new file with unix-timestamp format', done => {
+        prepare({
+          flags: _.assign({
+            'filename-date-format': 'unix-timestamp'
+          }, flags)
+        }, () => {
+          const timestamp   = Math.round(Date.now() / 1000);
+          const expectation = new RegExp(timestamp + '-' + migrationFile);
+
+          gulp
+            .src(Support.resolveSupportPath('tmp', 'migrations'))
+            .pipe(helpers.listFiles())
+            .pipe(helpers.ensureContent(expectation))
+            .pipe(helpers.teardown(done));
+        });
+      });
+
+      it('creates new file with unix-timestamp-millis format', done => {
+        prepare({
+          flags: _.assign({
+            'filename-date-format': 'unix-timestamp-millis'
+          }, flags)
+        }, () => {
+          const timestamp   = Date.now().toString().substr(0, 9);
+          const expectation = new RegExp(timestamp + '\\d{4}-' + migrationFile);
+
+          gulp
+            .src(Support.resolveSupportPath('tmp', 'migrations'))
+            .pipe(helpers.listFiles())
+            .pipe(helpers.ensureContent(expectation))
+            .pipe(helpers.teardown(done));
+        });
+      });
+
+      it('fails on unknown filename date format value', done => {
+        prepare({
+          flags: _.assign({
+            'filename-date-format': 'bar'
+          }, flags),
+          cli: { pipeStderr: true }
+        }, (_, stdout) => {
+          expect(stdout).to.match(
+            /Argument: filename-date-format, Given: "bar", Choices: "dateYYYYMMDDHHmms", "unix-timestamp", "unix-timestamp-millis"/
+          );
+          done();
+        });
+      });
+    });
+
     it('adds a skeleton with an up and a down method', done => {
-      prepare(() => {
+      prepare({ flags }, () => {
         gulp
           .src(Support.resolveSupportPath('tmp', 'migrations'))
           .pipe(helpers.readFile('*-' + migrationFile))

--- a/test/model/create.test.js
+++ b/test/model/create.test.js
@@ -10,16 +10,6 @@ const _         = require('lodash');
   'model:create'
 ].forEach(flag => {
   describe(Support.getTestDialectTeaser(flag), () => {
-    const combineFlags = function (flags) {
-      let result = flag;
-
-      _.forEach(flags || {}, (value, key) => {
-        result = result + ' --' + key + ' ' + value;
-      });
-
-      return result;
-    };
-
     const prepare = function (options, callback) {
       options = _.assign({
         flags: {},
@@ -30,7 +20,7 @@ const _         = require('lodash');
         .src(Support.resolveSupportPath('tmp'))
         .pipe(helpers.clearDirectory())
         .pipe(helpers.runCli('init'))
-        .pipe(helpers.runCli(combineFlags(options.flags), options.cli))
+        .pipe(helpers.runCli(helpers.buildCommand(flag, options.flags), options.cli))
         .pipe(helpers.teardown(callback));
     };
 
@@ -240,14 +230,14 @@ const _         = require('lodash');
             it('exits with an error code', function (done) {
               gulp
                 .src(Support.resolveSupportPath('tmp'))
-                .pipe(helpers.runCli(combineFlags(this.flags), { exitCode: 1 }))
+                .pipe(helpers.runCli(helpers.buildCommand(flag, this.flags), { exitCode: 1 }))
                 .pipe(helpers.teardown(done));
             });
 
             it('notifies the user about the possibility of --flags', function (done) {
               gulp
                 .src(Support.resolveSupportPath('tmp'))
-                .pipe(helpers.runCli(combineFlags(this.flags), { pipeStderr: true }))
+                .pipe(helpers.runCli(helpers.buildCommand(flag, this.flags), { pipeStderr: true }))
                 .pipe(helpers.teardown((err, stderr) => {
                   expect(stderr).to.contain('already exists');
                   done();

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -205,6 +205,13 @@ module.exports = {
     } else {
       return sequelize.query(sql, null, options);
     }
+  },
+  buildCommand: function (cmd, flags) {
+    let result = cmd;
+    _.forEach(flags || {}, (value, key) => {
+      result = result + ' --' + key + ' ' + value;
+    });
+    return result;
   }
 };
 


### PR DESCRIPTION
Hello! This is a request to add a new flag, `--filename-date-format` to the `migration:create` command.

This would allow for two new formats:
`unix-timestamp`
`unix-timestamp-millis`

so that this command:
`npx sequelize-cli migration:create --name foo --filename-date-format unix-timestamp-millis`
would create a file named:
`1574156777964-foo.js`

This change is fully backwards compatible and defaults to the `YYYYMMDDHHmms` date format.