### PR TITLE
feat: support uzmug `traverseDirectories` migration option

### DIFF
--- a/src/core/migrator.js
+++ b/src/core/migrator.js
@@ -49,6 +49,7 @@ export function getMigrator (type, args) {
         params: [sequelize.getQueryInterface(), Sequelize],
         path: helpers.path.getPath(type),
         pattern: /\.js$/,
+        traverseDirectories: args.traverseDirectories,
         wrap: fun => {
           if (fun.length === 3) {
             return Bluebird.promisify(fun);

--- a/src/core/yargs.js
+++ b/src/core/yargs.js
@@ -57,6 +57,11 @@ export function _baseOptions (yargs) {
       describe: 'When available show various debug information',
       default: false,
       type: 'boolean'
+    })
+    .options('traverseDirectories', {
+      describe: 'Search for migrations into subfolders',
+      default: false,
+      type: 'boolean',
     });
 }
 


### PR DESCRIPTION
### Main changes ###

 - [X] Added the ability to set `traverseDirectories: true` into `.sequelizerc` enabling migrations to be split into subfolders