### PR TITLE
Fix an issue for migration timestamps in mssql

### DIFF
--- a/src/core/migrator.js
+++ b/src/core/migrator.js
@@ -99,6 +99,11 @@ export function ensureCurrentMetaSchema (migrator) {
 function ensureMetaTable (queryInterface, tableName) {
   return queryInterface.showAllTables()
     .then(tableNames => {
+      // flatten table name array to only contain the table name and not the schema
+      tableNames = tableNames.map(function(name) {
+        return name.tableName === undefined ? name : name.tableName;
+      });
+
       if (tableNames.indexOf(tableName) === -1) {
         throw new Error('No MetaTable table found.');
       }


### PR DESCRIPTION
When working with mssql I noticed an issue when adding timestamps to the migrations table (via `npx sequelize db:migrate:schema:timestamps:add`) where the array returned from `queryInterface.showAllTables()` was returning an array with objects in it, like this:

```javascript
[
  {
    tableName: 'users',
    schema: 'dbo'
  },
  {
    tableName: 'SequelizeMeta',
    schema: 'dbo'
  }
]
```

This was causing `ensureMetaTable` to always fail, even though `SequelizeMeta` was there.

If this has been fixed, or there's a better way to resolve this let me know!

Thanks!