### PR TITLE
freezeTableName support

### DIFF
--- a/src/core/yargs.js
+++ b/src/core/yargs.js
@@ -68,7 +68,7 @@ export function _underscoreOption (yargs) {
       type: 'boolean'
     })
     .option('freezeTableName', {
-      describe: "prevent pluralizing the table name.",
+      describe: 'Use singular form for table name.',
       default: false,
       type: 'boolean'
     });

--- a/src/core/yargs.js
+++ b/src/core/yargs.js
@@ -66,5 +66,10 @@ export function _underscoreOption (yargs) {
       describe: "Use snake case for the timestamp's attribute names",
       default: false,
       type: 'boolean'
+    })
+    .option('freezeTableName', {
+      describe: "prevent pluralizing the table name.",
+      default: false,
+      type: 'boolean'
     });
 }

--- a/src/helpers/migration-helper.js
+++ b/src/helpers/migration-helper.js
@@ -10,7 +10,7 @@ module.exports = {
 
   generateTableCreationFileContent (args) {
     return helpers.template.render('migrations/create-table.js', {
-      tableName:  this.getTableName(args.name),
+      tableName:  args.freezeTableName ? args.name : this.getTableName(args.name),
       attributes: helpers.model.transformAttributes(args.attributes),
       createdAt:  args.underscored ? 'created_at' : 'createdAt',
       updatedAt:  args.underscored ? 'updated_at' : 'updatedAt'


### PR DESCRIPTION
Add support to allow singular table name.

Note: I cant think of name that can replace `_underscoreOption`.

```
sequelize-cli model:generate --underscored --name user --attributes first_name:string,last_name:string,email:string```