### PR TITLE
Remove operatorsAliases from the default config

### DIFF
--- a/src/helpers/config-helper.js
+++ b/src/helpers/config-helper.js
@@ -72,7 +72,6 @@ const api = {
         database: 'database_development',
         host: '127.0.0.1',
         dialect: 'mysql',
-        operatorsAliases: false
       },
       test: {
         username: 'root',
@@ -80,7 +79,6 @@ const api = {
         database: 'database_test',
         host: '127.0.0.1',
         dialect: 'mysql',
-        operatorsAliases: false
       },
       production: {
         username: 'root',
@@ -88,7 +86,6 @@ const api = {
         database: 'database_production',
         host: '127.0.0.1',
         dialect: 'mysql',
-        operatorsAliases: false
       }
     }, undefined, 2) + '\n';
   },


### PR DESCRIPTION
There's no point in having operatorAliases at the default config since [it is deprecated in sequelize v5](https://sequelize.org/master/manual/model-querying-basics.html#deprecated--operator-aliases) 

Manually removing it after `sequelize init` is an unnecessary step that we can cut to provide a better developer experience :)
![image](https://user-images.githubusercontent.com/20492786/80157922-a7cfe200-859d-11ea-8774-857a6564c1c3.png)
