### PR TITLE
Add support for timestamps in migration tables

### DIFF
--- a/src/core/migrator.js
+++ b/src/core/migrator.js
@@ -77,6 +77,8 @@ export function ensureCurrentMetaSchema(migrator) {
       if (columns.length === 1 && columns[0] === columnName) {
         return;
       } else if (columns.length === 3 && columns.indexOf('createdAt') >= 0) {
+        // If found createdAt - indicate we have timestamps enabled
+        helpers.umzug.enableTimestamps();
         return;
       }
     })

--- a/src/helpers/umzug-helper.js
+++ b/src/helpers/umzug-helper.js
@@ -15,6 +15,8 @@ const storageJsonName = {
   seeder: 'sequelize-data.json',
 };
 
+let timestampsDefault = false;
+
 module.exports = {
   getStorageOption(property, fallback) {
     return helpers.config.readConfig()[property] || fallback;
@@ -41,6 +43,14 @@ module.exports = {
     return this.getStorageOption(type + 'StorageTableSchema', undefined);
   },
 
+  enableTimestamps() {
+    timestampsDefault = true;
+  },
+
+  getTimestamps(type) {
+    return this.getStorageOption(type + 'Timestamps', timestampsDefault);
+  },
+
   getStorageOptions(type, extraOptions) {
     const options = {};
 
@@ -49,6 +59,7 @@ module.exports = {
     } else if (this.getStorage(type) === 'sequelize') {
       options.tableName = this.getTableName(type);
       options.schema = this.getSchema(type);
+      options.timestamps = this.getTimestamps(type);
     }
 
     _.assign(options, extraOptions);

--- a/test/db/migrate/schema/add_timestamps.test.js
+++ b/test/db/migrate/schema/add_timestamps.test.js
@@ -118,5 +118,25 @@ const gulp = require('gulp');
           })
         );
     });
+
+    it('run migration again with timestamp fields present', function (done) {
+      gulp
+        .src(Support.resolveSupportPath('tmp'))
+        .pipe(helpers.runCli('db:migrate'))
+        .pipe(
+          helpers.teardown(() => {
+            helpers
+              .execQuery(
+                this.sequelize,
+                this.queryGenerator.selectQuery('SequelizeMeta'),
+                { raw: true, type: 'SELECT' }
+              )
+              .then((items) => {
+                expect(items.length).to.equal(2);
+                done();
+              });
+          })
+        );
+    });
   });
 });


### PR DESCRIPTION
The relevant fields are: `seedersTimestamps` and `migrationTimestamps` which can be set in the sequelize `config.json`

The code will also autodetect if the table already has the timestamps and will act upon it.