### PR TITLE
support a migration with a cjs extension

### DIFF
--- a/src/core/migrator.js
+++ b/src/core/migrator.js
@@ -49,7 +49,7 @@ export function getMigrator (type, args) {
       migrations: {
         params: [sequelize.getQueryInterface(), Sequelize],
         path: helpers.path.getPath(type),
-        pattern: /\.js$/,
+        pattern: /\.c?js$/,
         wrap: fun => {
           if (fun.length === 3) {
             return promisify(fun);

--- a/test/db/migrate.test.js
+++ b/test/db/migrate.test.js
@@ -26,7 +26,9 @@ const _         = require('lodash');
     const config        = _.assign({}, helpers.getTestConfig(), options.config);
     let configContent = JSON.stringify(config);
 
-    migrationFile = migrationFile + '.js';
+    if(!migrationFile.match(/\.cjs$/)){
+      migrationFile = migrationFile + '.js';
+    }
     if (flag.match(/config\.js$/)) {
       configPath    = configPath + 'config.js';
       configContent = 'module.exports = ' + configContent;
@@ -124,6 +126,20 @@ const _         = require('lodash');
         }, {
           migrationFile: 'new/*createPerson',
           config:        { promisifyMigrations: false }
+        });
+      });
+    });
+
+    describe('migrations with cjs extension', () => {
+      it('correctly migrates', function (done) {
+        const self = this;
+        prepare(() => {
+          helpers.readTables(self.sequelize, tables => {
+            expect(tables.sort()).to.contain('Comment');
+            done();
+          });
+        }, {
+          migrationFile: 'cjs/*createComment.cjs'
         });
       });
     });

--- a/test/support/assets/migrations/cjs/20200617063700-createComment.cjs
+++ b/test/support/assets/migrations/cjs/20200617063700-createComment.cjs
@@ -1,0 +1,17 @@
+'use strict';
+
+var nodeify = require('nodeify');
+
+module.exports = {
+  up: function (migration, DataTypes, done) {
+    nodeify(migration
+      .createTable('Comment', {
+        title: DataTypes.STRING,
+        body: DataTypes.TEXT
+      }), done);
+  },
+
+  down: function (migration, DataTypes, done) {
+    nodeify(migration.dropTable('Comment'), done);
+  }
+};


### PR DESCRIPTION
we are using ESM and this minimally supports a migration file with a cjs extension. 

Having this allows us to use sequelize and commonJS-based migrations within a module-enabled application.