### PR TITLE
add prepare script for git-based vendoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "build-assets": "cp -R ./src/assets ./lib/",
     "build-clean": "rm -rf ./lib/",
     "lint": "eslint test src",
+    "prepare": "npm run build",
     "test-raw": "mocha $npm_package_options_mocha 'test/**/*.test.js'",
     "test": "npm run lint && npm run build && npm run test-raw"
   },


### PR DESCRIPTION
If one wants to vendor a forked version of the module, they can't run the `bin` scripts because the package hasn't transpiled. 

Adding a `prepare` script will address that.