### PR TITLE
feat: recommend matching commands

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -60,4 +60,5 @@ yargs
   .wrap(yargs.terminalWidth())
   .demandCommand(1, 'Please specify a command')
   .help()
-  .strict().argv;
+  .strict()
+  .recommendCommands().argv;


### PR DESCRIPTION
The `command-recommendation` feature comes in handy if the user mistypes a command. 