### PR TITLE
Use DataTypes from sequelize instead of injecting into the migrations and Models

### DIFF
--- a/src/assets/migrations/create-table.js
+++ b/src/assets/migrations/create-table.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { DataTypes } from 'sequelize';
+const DataTypes = require('sequelize');
 
 module.exports = {
   up: async (queryInterface) => {

--- a/src/assets/migrations/create-table.js
+++ b/src/assets/migrations/create-table.js
@@ -1,34 +1,36 @@
 'use strict';
 
+import { DataTypes } from 'sequelize';
+
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
+  up: async (queryInterface) => {
     await queryInterface.createTable('<%= tableName %>', {
       id: {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: DataTypes.INTEGER
       },
 
       <% attributes.forEach(function(attribute) { %>
         <%= attribute.fieldName %>: {
-          type: Sequelize.<%= attribute.dataFunction ? `${attribute.dataFunction.toUpperCase()}(Sequelize.${attribute.dataType.toUpperCase()})` : attribute.dataValues ? `${attribute.dataType.toUpperCase()}(${attribute.dataValues})` : attribute.dataType.toUpperCase() %>
+          type: DataTypes.<%= attribute.dataFunction ? `${attribute.dataFunction.toUpperCase()}(DataTypes.${attribute.dataType.toUpperCase()})` : attribute.dataValues ? `${attribute.dataType.toUpperCase()}(${attribute.dataValues})` : attribute.dataType.toUpperCase() %>
         },
       <% }) %>
 
       <%= createdAt %>: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: DataTypes.DATE
       },
 
       <%= updatedAt %>: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: DataTypes.DATE
       }
     });
   },
 
-  down: async (queryInterface, Sequelize) => {
+  down: async (queryInterface) => {
     await queryInterface.dropTable('<%= tableName %>');
   }
 };

--- a/src/assets/migrations/create-table.js
+++ b/src/assets/migrations/create-table.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const DataTypes = require('sequelize');
+const { DataTypes } = require('sequelize');
 
 module.exports = {
   up: async (queryInterface) => {

--- a/src/assets/migrations/skeleton.js
+++ b/src/assets/migrations/skeleton.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { DataTypes } from 'sequelize';
+const DataTypes = require('sequelize');
 
 module.exports = {
   up: async (queryInterface) => {

--- a/src/assets/migrations/skeleton.js
+++ b/src/assets/migrations/skeleton.js
@@ -1,16 +1,18 @@
 'use strict';
 
+import { DataTypes } from 'sequelize';
+
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
+  up: async (queryInterface) => {
     /**
      * Add altering commands here.
      *
      * Example:
-     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     * await queryInterface.createTable('users', { id: DataTypes.INTEGER });
      */
   },
 
-  down: async (queryInterface, Sequelize) => {
+  down: async (queryInterface) => {
     /**
      * Add reverting commands here.
      *

--- a/src/assets/migrations/skeleton.js
+++ b/src/assets/migrations/skeleton.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const DataTypes = require('sequelize');
+const { DataTypes } = require('sequelize');
 
 module.exports = {
   up: async (queryInterface) => {

--- a/src/assets/models/model.js
+++ b/src/assets/models/model.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const { Model } = require('sequelize');
+const { Model, DataTypes } = require('sequelize');
 
-module.exports = (sequelize, DataTypes) => {
+module.exports = (sequelize) => {
   class <%= name %> extends Model {
     /**
      * Helper method for defining associations.

--- a/test/migration/create.test.js
+++ b/test/migration/create.test.js
@@ -47,7 +47,7 @@ const gulp = require('gulp');
             helpers.expect((stdout) => {
               expect(stdout).to.contain('up: async (queryInterface) => {');
               expect(stdout).to.contain(
-                "import { DataTypes } from 'sequelize';"
+                "const DataTypes = require('sequelize');"
               );
               expect(stdout).to.contain('down: async (queryInterface) => {');
             })

--- a/test/migration/create.test.js
+++ b/test/migration/create.test.js
@@ -45,12 +45,11 @@ const gulp = require('gulp');
           .pipe(helpers.readFile('*-' + migrationFile))
           .pipe(
             helpers.expect((stdout) => {
+              expect(stdout).to.contain('up: async (queryInterface) => {');
               expect(stdout).to.contain(
-                'up: async (queryInterface, Sequelize) => {'
+                "import { DataTypes } from 'sequelize';"
               );
-              expect(stdout).to.contain(
-                'down: async (queryInterface, Sequelize) => {'
-              );
+              expect(stdout).to.contain('down: async (queryInterface) => {');
             })
           )
           .pipe(helpers.teardown(done));

--- a/test/migration/create.test.js
+++ b/test/migration/create.test.js
@@ -47,7 +47,7 @@ const gulp = require('gulp');
             helpers.expect((stdout) => {
               expect(stdout).to.contain('up: async (queryInterface) => {');
               expect(stdout).to.contain(
-                "const DataTypes = require('sequelize');"
+                "const { DataTypes } = require('sequelize');"
               );
               expect(stdout).to.contain('down: async (queryInterface) => {');
             })

--- a/test/model/create.test.js
+++ b/test/model/create.test.js
@@ -213,27 +213,27 @@ const _ = require('lodash');
                         .pipe(helpers.ensureContent(".createTable('Users', {"))
                         .pipe(
                           helpers.ensureContent(
-                            'first_name: {\n        type: Sequelize.STRING\n      },'
+                            'first_name: {\n        type: DataTypes.STRING\n      },'
                           )
                         )
                         .pipe(
                           helpers.ensureContent(
-                            'last_name: {\n        type: Sequelize.STRING\n      },'
+                            'last_name: {\n        type: DataTypes.STRING\n      },'
                           )
                         )
                         .pipe(
                           helpers.ensureContent(
-                            'bio: {\n        type: Sequelize.TEXT\n      },'
+                            'bio: {\n        type: DataTypes.TEXT\n      },'
                           )
                         )
                         .pipe(
                           helpers.ensureContent(
-                            "role: {\n        type: Sequelize.ENUM('Admin', 'Guest User')\n      },"
+                            "role: {\n        type: DataTypes.ENUM('Admin', 'Guest User')\n      },"
                           )
                         )
                         .pipe(
                           helpers.ensureContent(
-                            'reviews: {\n        type: Sequelize.ARRAY(Sequelize.TEXT)\n      },'
+                            'reviews: {\n        type: DataTypes.ARRAY(DataTypes.TEXT)\n      },'
                           )
                         )
                         .pipe(
@@ -243,7 +243,7 @@ const _ = require('lodash');
                               '        allowNull: false,',
                               '        autoIncrement: true,',
                               '        primaryKey: true,',
-                              '        type: Sequelize.INTEGER',
+                              '        type: DataTypes.INTEGER',
                               '      },',
                             ].join('\n')
                           )
@@ -253,7 +253,7 @@ const _ = require('lodash');
                             [
                               '     ' + attrUnd.createdAt + ': {',
                               '        allowNull: false,',
-                              '        type: Sequelize.DATE',
+                              '        type: DataTypes.DATE',
                               '      },',
                             ].join('\n')
                           )
@@ -263,7 +263,7 @@ const _ = require('lodash');
                             [
                               '     ' + attrUnd.updatedAt + ': {',
                               '        allowNull: false,',
-                              '        type: Sequelize.DATE',
+                              '        type: DataTypes.DATE',
                               '      }',
                             ].join('\n')
                           )


### PR DESCRIPTION
Import and use DataTypes from `sequelize` instead of injecting into the migrations and models
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Import and using DataTypes from `sequelize` allows for auto completion and type hinting.