### PR TITLE
Update migrator pattern to not match .d.ts files 

### DIFF
--- a/src/core/migrator.js
+++ b/src/core/migrator.js
@@ -45,7 +45,7 @@ export async function getMigrator(type, args) {
     migrations: {
       params: [sequelize.getQueryInterface(), Sequelize],
       path: helpers.path.getPath(type),
-      pattern: /\.(cjs|js|ts)$/,
+      pattern: /^(?!.*\.d\.ts$).*\.(cjs|js|ts)$/,
     },
   });
 

--- a/test/db/migrate.test.js
+++ b/test/db/migrate.test.js
@@ -169,6 +169,23 @@ const _ = require('lodash');
       });
     });
 
+    describe('migrations to not match .d.ts extension', () => {
+      it("doesn't match", function (done) {
+        const self = this;
+        prepare(
+          () => {
+            helpers.readTables(self.sequelize, (tables) => {
+              expect(tables.sort()).to.not.contain('TypescriptDS');
+              done();
+            });
+          },
+          {
+            migrationFile: 'ts/*.d.ts',
+          }
+        );
+      });
+    });
+
     describe('custom meta table name', () => {
       it('correctly uses the defined table name', function (done) {
         const self = this;

--- a/test/support/assets/migrations/ts/20200817171700-createTypescriptDS.d.ts
+++ b/test/support/assets/migrations/ts/20200817171700-createTypescriptDS.d.ts
@@ -1,0 +1,15 @@
+//@ts-ignore
+
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, DataTypes) => {
+    await queryInterface.createTable('TypescriptDS', {
+      title: DataTypes.STRING,
+      body: DataTypes.TEXT,
+    });
+  },
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('TypescriptDS');
+  },
+};


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Changed the migrator pattern to not match `.d.ts` files.

[Here's](https://regexr.com/5abb5) the regexr playground for seeing the new pattern in action

[Here's](https://stackoverflow.com/questions/43490499/webpack-regex-test-that-matches-ts-but-not-d-ts) the source where I got the pattern

Current workaround I use is to run `rimraf dist/migrations/*.d.ts` before running migrations. 

