### PR TITLE
Add db:info command which returns database configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "pretty": "prettier src test --write",
     "prepare": "husky install && npm run build",
     "test-raw": "mocha 'test/**/*.test.js'",
-    "test": "npm run lint && npm run build && npm run test-raw"
+    "test": "npm run lint && npm run build && npm run test-raw",
+    "test-one": "mocha 'test/db/db-info.test.js'"
   },
   "repository": {
     "type": "git",

--- a/src/commands/database.js
+++ b/src/commands/database.js
@@ -29,6 +29,11 @@ exports.builder = (yargs) =>
     .option('template', {
       describe: 'Pass template option to dialect, PostgreSQL only',
       type: 'string',
+    })
+    .option('show-password', {
+      describe: 'Will show password as plain text',
+      type: 'boolean',
+      default: false,
     }).argv;
 
 exports.handler = async function (args) {
@@ -52,13 +57,12 @@ exports.handler = async function (args) {
     queryInterface.queryGenerator || queryInterface.QueryGenerator;
 
   const query = getCreateDatabaseQuery(sequelize, config, options);
+  let configOutput = '';
 
   switch (command) {
     case 'db:info':
-      if (config.password !== null) {
-        config.password = '***';
-      }
-      helpers.view.log('Config', config);
+      configOutput = transformConfigObject(config, args['show-password']);
+      helpers.view.log('Config', configOutput);
       break;
     case 'db:create':
       await sequelize
@@ -187,5 +191,11 @@ function getDatabaseLessSequelize() {
     return new Sequelize(config);
   } catch (e) {
     helpers.view.error(e);
+  }
+}
+
+function transformConfigObject(config, showPassword) {
+  if (config.password !== null && !showPassword) {
+    config.password = '***';
   }
 }

--- a/src/commands/database.js
+++ b/src/commands/database.js
@@ -54,6 +54,12 @@ exports.handler = async function (args) {
   const query = getCreateDatabaseQuery(sequelize, config, options);
 
   switch (command) {
+    case 'db:info':
+      if (config.password !== null) {
+        config.password = '***';
+      }
+      helpers.view.log('Config', config);
+      break;
     case 'db:create':
       await sequelize
         .query(query, {

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -35,6 +35,7 @@ yargs
   .command('db:seed:undo', 'Deletes data from the database', seedOne)
   .command('db:seed:all', 'Run every seeder', seed)
   .command('db:seed:undo:all', 'Deletes data from the database', seed)
+  .command('db:info', 'Return database configuration info', database)
   .command('db:create', 'Create database specified by configuration', database)
   .command('db:drop', 'Drop database specified by configuration', database)
   .command('init', 'Initializes project', init)

--- a/test/db/db-info.test.js
+++ b/test/db/db-info.test.js
@@ -1,0 +1,33 @@
+// const expect = require('expect.js');
+const Support = require(__dirname + '/../support');
+const helpers = require(__dirname + '/../support/helpers');
+const gulp = require('gulp');
+const _ = require('lodash');
+
+const prepare = function (flag, callback, options) {
+  options = _.assign({ config: {} }, options || {});
+
+  const configPath = 'config/config.json';
+  const config = _.assign({}, helpers.getTestConfig(), options.config);
+  const configContent = JSON.stringify(config);
+
+  gulp
+    .src(Support.resolveSupportPath('tmp'))
+    .pipe(helpers.clearDirectory())
+    .pipe(helpers.runCli('init'))
+    .pipe(helpers.removeFile(configPath))
+    .pipe(helpers.overwriteFile(configContent, configPath))
+    .pipe(helpers.runCli(flag, { pipeStdout: true }))
+    .pipe(helpers.teardown(callback));
+};
+
+['db:info'].forEach((flag) => {
+  describe(Support.getTestDialectTeaser(flag), () => {
+    (function (folders) {
+      folders.forEach((folder) => {
+        prepare(); // wip
+        console.log('oo', folder);
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

I wanted to add a way to quickly check if a command would be performed against the correct database connection.

Add the `db:info` command. 

Outputs:
```bash
Config {
  username: 'root',
  password: '***',
  database: 'test_database',
  host: 'localhost',
  port: '3306',
  dialect: 'mysql'
}
```

This isn't really very polished and no additional tests have been written to cover the command. I mainly wanted to open this PR to get comments and/or suggestions since I'm currently using this version for my current projects.

<!-- Please provide a description of the change here. -->
