### PR TITLE
fix: model:generate formatAttributes

### DIFF
--- a/src/helpers/model-helper.js
+++ b/src/helpers/model-helper.js
@@ -27,7 +27,7 @@ function formatAttributes(attribute) {
       dataValues: null,
     };
   } else if (split.length === 3) {
-    const validValues = /^\{(,? ?[A-z0-9 ]+)+\}$/;
+    const validValues = /^\[(,? ?("|')?[A-z0-9 ]+("|')?)+\]$/;
     const isValidFunction =
       validAttributeFunctionType.indexOf(split[1].toLowerCase()) !== -1;
     const isValidValue =
@@ -50,7 +50,7 @@ function formatAttributes(attribute) {
         dataType: split[1],
         dataFunction: null,
         dataValues: split[2]
-          .replace(/(^\{|\}$)/g, '')
+          .replace(/(^'|"|\[|\]$)/g, '')
           .split(/\s*,\s*/)
           .map((s) => `'${s}'`)
           .join(', '),
@@ -65,9 +65,10 @@ module.exports = {
   transformAttributes(flag) {
     /*
       possible flag formats:
-      - first_name:string,last_name:string,bio:text,role:enum:{Admin, 'Guest User'},reviews:array:string
-      - 'first_name:string last_name:string bio:text role:enum:{Admin, Guest User} reviews:array:string'
-      - 'first_name:string, last_name:string, bio:text, role:enum:{Admin, Guest User} reviews:array:string'
+      - first_name:string,last_name:string,bio:text,role:enum:{Admin,"Guest User"},reviews:array:text,
+      - first_name:string,last_name:string,bio:text,role:enum:[Admin, 'Guest User'],reviews:array:string
+      - 'first_name:string last_name:string bio:text role:enum:[Admin, Guest User] reviews:array:string'
+      - 'first_name:string, last_name:string, bio:text, role:enum:[Admin, Guest User] reviews:array:string'
     */
     const attributeStrings = flag
       .split('')
@@ -78,10 +79,10 @@ module.exports = {
             if ((a === ',' || a === ' ') && !openValues) {
               return '  ';
             }
-            if (a === '{') {
+            if (a === '[') {
               openValues = true;
             }
-            if (a === '}') {
+            if (a === ']') {
               openValues = false;
             }
 

--- a/test/model/create.test.js
+++ b/test/model/create.test.js
@@ -98,10 +98,10 @@ const _ = require('lodash');
         });
       });
       [
-        'first_name:string,last_name:string,bio:text,role:enum:{Admin,"Guest User"},reviews:array:text',
-        "first_name:string,last_name:string,bio:text,role:enum:{Admin,'Guest User'},reviews:array:text",
-        "'first_name:string last_name:string bio:text role:enum:{Admin,Guest User} reviews:array:text'",
-        "'first_name:string, last_name:string, bio:text, role:enum:{Admin, Guest User}, reviews:array:text'",
+        'first_name:string,last_name:string,bio:text,role:enum:[Admin,"Guest User"],reviews:array:text',
+        "first_name:string,last_name:string,bio:text,role:enum:[Admin,'Guest User'],reviews:array:text",
+        "'first_name:string last_name:string bio:text role:enum:[Admin,Guest User] reviews:array:text'",
+        "'first_name:string, last_name:string, bio:text, role:enum:[Admin, Guest User], reviews:array:text'",
       ].forEach((attributes) => {
         describe('--attributes ' + attributes, () => {
           it('exits with exit code 0', (done) => {


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

When I ran the tests, [these four test cases](https://github.com/sequelize/cli/blob/be5b445619b59115f36f06507bfff7aa87528db8/test/model/create.test.js#L100) failed.


> 'first_name:string,last_name:string,bio:text,role:enum:{Admin,"Guest User"},reviews:array:text',
        "first_name:string,last_name:string,bio:text,role:enum:{Admin,'Guest User'},reviews:array:text",
        "'first_name:string last_name:string bio:text role:enum:{Admin,Guest User} reviews:array:text'",
        "'first_name:string, last_name:string, bio:text, role:enum:{Admin, Guest User}, reviews:array:text'",

The reason was `{` and `}` are special characters in the terminal so either we should wrapp attributes in quotation or double quotation or replace `{` and `}` with `[` and `]` which I thought is the best solution since its like the Sequelize API itself. Updated tests and comments too. but there isn't any section about this subject in documents. (at least I didn't find)

Also, the regex didn't support `"Guest User"` or `'Guest User'` so I fixed that.
