### PR TITLE
Add db:create and db:drop support for MariaDB

### DIFF
--- a/src/commands/database.js
+++ b/src/commands/database.js
@@ -109,6 +109,7 @@ function getCreateDatabaseQuery(sequelize, config, options) {
       );
 
     case 'mysql':
+    case 'mariadb':
       return (
         'CREATE DATABASE IF NOT EXISTS ' +
         queryGenerator.quoteIdentifier(config.database) +
@@ -163,6 +164,7 @@ function getDatabaseLessSequelize() {
       break;
 
     case 'mysql':
+    case 'mariadb':
       delete config.database;
       break;
 


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` pass with this change (including linting)? 
**No, but linting issues are unrelated to my change.**
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
**I have db drop and create tests that pass. Some of the other pre-existing tests do not pass locally for me.**
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Adds support for db:create and db:drop for MariaDB. This uses the same code block as MySQL since they are compatible.

I can push up the tests if you want. It's just an extra `if (Support.dialectIsMariaDB()) {` in the db-create and db-drop test files.
