### PR TITLE
feat: add jsdoc to migration template

### DIFF
--- a/src/assets/migrations/skeleton.js
+++ b/src/assets/migrations/skeleton.js
@@ -1,6 +1,10 @@
 'use strict';
 
 module.exports = {
+   /**
+   * @param { import('sequelize/lib/query-interface')} sqlQueryInterface
+   * @param { import('sequelize') } Sequelize
+   */
   up: async (queryInterface, Sequelize) => {
     /**
      * Add altering commands here.
@@ -10,6 +14,10 @@ module.exports = {
      */
   },
 
+   /**
+   * @param { import('sequelize/lib/query-interface')} sqlQueryInterface
+   * @param { import('sequelize') } Sequelize
+   */
   down: async (queryInterface, Sequelize) => {
     /**
      * Add reverting commands here.


### PR DESCRIPTION
### Pull Request check-list

Not relevant for the changes made

### Description of change

Currently the skeleton is in .js and therefore in many IDE we do not have autocompletion when writing migrations.
Adding jsdoc types make it works for many ides.

Not a breaking change
