### PR TITLE
meta(mocha): move mocha config to own file

### DIFF
--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,0 +1,7 @@
+bail: true
+check-leaks: true
+color: true
+exit: true
+recursive: true
+require: '@babel/register'
+timeout: '30000'

--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
     "sqlite3": "latest",
     "through2": "^4.0.0"
   },
-  "options": {
-    "mocha": "--require scripts/mocha-bootload.js --bail --check-leaks --exit --timeout 30000 --colors --recursive --reporter spec"
-  },
   "prettier": {
     "trailingComma": "es5",
     "tabWidth": 2,
@@ -59,7 +56,7 @@
     "lint": "eslint test src",
     "pretty": "prettier src test --write",
     "prepare": "husky install && npm run build",
-    "test-raw": "mocha $npm_package_options_mocha 'test/**/*.test.js'",
+    "test-raw": "mocha 'test/**/*.test.js'",
     "test": "npm run lint && npm run build && npm run test-raw"
   },
   "repository": {

--- a/scripts/mocha-bootload.js
+++ b/scripts/mocha-bootload.js
@@ -1,1 +1,0 @@
-require('@babel/register');


### PR DESCRIPTION
In some of the Node 16 tests for #974 it seemed that mocha was not on a timeout of 30000 but on the default 2000. Not sure why but by moving it to a separate config file it works [fine](https://github.com/WikiRik/cli/actions/runs/1435493979). The config can also be a part of package.json as a mocha property but I prefer to move it to its own config file.

Reporter spec was removed since it is the [default](https://mochajs.org/#-reporter-name-r-name).

I also removed the script, since it only required one thing so it can also be a part of the config file. As per; https://github.com/mochajs/mocha/blob/master/example/config/.mocharc.yml