### PR TITLE
feat(types): Improve IntelliSense when generating migration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sequelize-cli",
   "version": "6.3.0",
   "description": "The Sequelize CLI",
+  "types": "./types.d.ts",
   "bin": {
     "sequelize": "./lib/sequelize",
     "sequelize-cli": "./lib/sequelize"

--- a/src/assets/migrations/create-table.js
+++ b/src/assets/migrations/create-table.js
@@ -1,5 +1,6 @@
 'use strict';
 
+/** @type {import('sequelize-cli').Migration} */
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.createTable('<%= tableName %>', {

--- a/src/assets/migrations/skeleton.js
+++ b/src/assets/migrations/skeleton.js
@@ -1,5 +1,6 @@
 'use strict';
 
+/** @type {import('sequelize-cli').Migration} */
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     /**

--- a/src/assets/seeders/skeleton.js
+++ b/src/assets/seeders/skeleton.js
@@ -1,5 +1,6 @@
 'use strict';
 
+/** @type {import('sequelize-cli').Migration} */
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,12 @@
+import type { QueryInterface } from 'sequelize';
+
+export interface Migration {
+  up(
+    queryInterface: QueryInterface,
+    Sequelize: typeof import('sequelize')
+  ): Promise<void>;
+  down(
+    queryInterface: QueryInterface,
+    Sequelize: typeof import('sequelize')
+  ): Promise<void>;
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,12 +1,10 @@
-import type { QueryInterface } from 'sequelize';
-
 export interface Migration {
   up(
-    queryInterface: QueryInterface,
+    queryInterface: import('sequelize').QueryInterface,
     Sequelize: typeof import('sequelize')
   ): Promise<void>;
   down(
-    queryInterface: QueryInterface,
+    queryInterface: import('sequelize').QueryInterface,
     Sequelize: typeof import('sequelize')
   ): Promise<void>;
 }


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] ~~Have you added new tests to prevent regressions?~~
- [ ] ~~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~~

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Problem: No IntelliSense when working on migration files

![image](https://user-images.githubusercontent.com/193136/140884244-d1f40fed-b2ed-4c2b-83d9-b0d5058172ab.png)

Solution: Add a type definition file and use `/** @type */` tag to make editors infer the type of each variable.

![image](https://user-images.githubusercontent.com/193136/140884649-fc2f0a6f-5309-4680-93c4-0015cf2a6daf.png)
