### PR TITLE
feat: added support for ESM config files

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,5 +10,13 @@
   ],
   "ignore": [
     "src/assets"
-  ]
+  ],
+  "overrides": [{
+    "test": "./src/helpers/import-helper.js",
+    "presets": [
+      ["@babel/env", {
+        "exclude": ["proposal-dynamic-import"],
+      }]
+    ],
+  }]
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "pg": "latest",
     "pg-hstore": "latest",
     "prettier": "^2.4.1",
+    "semver": "^7.3.5",
     "sequelize": "^6.9.0",
     "sqlite3": "latest",
     "through2": "^4.0.2"

--- a/src/helpers/config-helper.js
+++ b/src/helpers/config-helper.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import { promisify } from 'util';
 import helpers from './index';
 import getYArgs from '../core/yargs';
+import importHelper from './import-helper';
 
 const args = getYArgs().argv;
 
@@ -15,18 +16,19 @@ const api = {
   init() {
     return Promise.resolve()
       .then(() => {
-        let config;
-
         if (args.url) {
-          config = api.parseDbUrl(args.url);
+          return api.parseDbUrl(args.url);
         } else {
-          try {
-            config = require(api.getConfigFile());
-          } catch (e) {
-            api.error = e;
-          }
+          return importHelper.importModule(api.getConfigFile());
         }
-        return config;
+      })
+      .then((module) => module.default)
+      .catch(() => {
+        try {
+          return require(api.getConfigFile());
+        } catch (e) {
+          api.error = e;
+        }
       })
       .then((config) => {
         if (typeof config === 'object' || config === undefined) {

--- a/src/helpers/import-helper.js
+++ b/src/helpers/import-helper.js
@@ -1,0 +1,5 @@
+module.exports = {
+  importModule: function (module) {
+    return import(module);
+  },
+};

--- a/test/db/migrate.test.js
+++ b/test/db/migrate.test.js
@@ -3,6 +3,7 @@ const expect = require('expect.js');
 const Support = require(__dirname + '/../support');
 const helpers = require(__dirname + '/../support/helpers');
 const gulp = require('gulp');
+const semver = require('semver');
 const _ = require('lodash');
 
 [
@@ -293,6 +294,54 @@ describe(Support.getTestDialectTeaser('db:migrate'), () => {
   });
 });
 
+describeOnlyForESM(Support.getTestDialectTeaser('db:migrate'), () => {
+  describe('with config.mjs', () => {
+    const prepare = function (callback) {
+      const config = helpers.getTestConfig();
+      const configContent = 'export default ' + JSON.stringify(config);
+      let result = '';
+
+      return gulp
+        .src(Support.resolveSupportPath('tmp'))
+        .pipe(helpers.clearDirectory())
+        .pipe(helpers.runCli('init'))
+        .pipe(helpers.removeFile('config/config.json'))
+        .pipe(helpers.copyMigration('createPerson.js'))
+        .pipe(helpers.overwriteFile(configContent, 'config/config.mjs'))
+        .pipe(helpers.runCli('db:migrate --config config/config.mjs'))
+        .on('error', (e) => {
+          callback(e);
+        })
+        .on('data', (data) => {
+          result += data.toString();
+        })
+        .on('end', () => {
+          callback(null, result);
+        });
+    };
+
+    it('creates a SequelizeMeta table', function (done) {
+      prepare(() => {
+        helpers.readTables(this.sequelize, (tables) => {
+          expect(tables).to.have.length(2);
+          expect(tables).to.contain('SequelizeMeta');
+          done();
+        });
+      });
+    });
+
+    it('creates the respective table', function (done) {
+      prepare(() => {
+        helpers.readTables(this.sequelize, (tables) => {
+          expect(tables).to.have.length(2);
+          expect(tables).to.contain('Person');
+          done();
+        });
+      });
+    });
+  });
+});
+
 describe(Support.getTestDialectTeaser('db:migrate'), () => {
   describe('with config.json and url option', () => {
     const prepare = function (callback) {
@@ -525,3 +574,11 @@ describe(Support.getTestDialectTeaser('db:migrate'), () => {
     });
   });
 });
+
+function describeOnlyForESM(title, fn) {
+  if (semver.satisfies(process.version, '^12.20.0 || ^14.13.1 || >=16.0.0')) {
+    describe(title, fn);
+  } else {
+    describe.skip(title, fn);
+  }
+}


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Added support for config files that are ESM, usually the migrations themselves are generated so they are commonjs.  
But on the other hand the config could be in ESM in case the backend uses ESM.  

This PR fixes that by trying to import the config file as an ECMAScript module first, and if it fails it fallbacks to CommonJS.  

I've also had to change the babel config, so that it won't transpile the dynamic import to CommonJS as well.

Let me know if a change to the docs is necessary, and if so where to put it.  

This PR also means that the new tests will fail on Node versions older than 12.20, but the failure will be graceful and CommonJS will work instead, since ESM doesn't work in Node versions earlier than that.