### PR TITLE
Fix ssl config option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -109,7 +109,9 @@ Ensure ssl is specified in both `dialectOptions` and in the base config.
         "dialect":"postgres",
         "ssl": true,
         "dialectOptions": {
-            "ssl": true
+            "ssl": {
+                "require": true
+            }
         }
     }
 }


### PR DESCRIPTION
### Description of change

Fix this error:

```

Loaded configuration file "config/config.json".
Using environment "development".

ERROR: SSL profile must be an object, instead it's a boolean
```
