### PR TITLE
build: add semantic-release config

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,5 +116,23 @@
   },
   "lint-staged": {
     "*.js": "eslint"
+  },
+  "release": {
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
+      "@semantic-release/github"
+    ],
+    "branches": [
+      "v6",
+      {
+        "name": "v7",
+        "prerelease": "alpha"
+      }
+    ]
+  },
+  "publishConfig": {
+    "tag": "alpha"
   }
 }


### PR DESCRIPTION
Yeah, so in https://github.com/sequelize/cli/pull/972 we didn't notice that it didn't actually add the config for semantic-release. But now it should hopefully work, this is just a copy from the core repo