### PR TITLE
fix: fix config import breaking on windows

### DIFF
--- a/src/helpers/import-helper.js
+++ b/src/helpers/import-helper.js
@@ -1,3 +1,5 @@
+const url = require('url');
+
 async function supportsDynamicImport() {
   try {
     // imports are cached.
@@ -20,8 +22,13 @@ async function supportsDynamicImport() {
 async function importModule(modulePath) {
   // JSON modules are still behind a flag. Fallback to require for now.
   // https://nodejs.org/api/esm.html#json-modules
-  if (!modulePath.endsWith('.json') && (await supportsDynamicImport())) {
-    return import(modulePath);
+  if (
+    url.pathToFileURL &&
+    !modulePath.endsWith('.json') &&
+    (await supportsDynamicImport())
+  ) {
+    // 'import' expects a URL. (https://github.com/sequelize/cli/issues/994)
+    return import(url.pathToFileURL(modulePath));
   }
 
   // mimics what `import()` would return for


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions? **Can't as we don't test on windows**
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

https://github.com/sequelize/cli/pull/987 introduced a bug that caused sequelize-cli to be unusable on windows, as it tries to import the config file using `import()` instead of `require()`. Unlike `require`, `import` expects the path to be a valid URL.

Closes https://github.com/sequelize/cli/issues/994