### PR TITLE
build: only pin devDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "config:base"
+    "config:js-lib"
   ]
 }


### PR DESCRIPTION
config:base detects if the repo is an app or a library. For the main repo it's obviously a library and for CLI it detected this as an app. This change makes sure that we use the library config. As per; https://docs.renovatebot.com/presets-config/#configjs-lib