### PR TITLE
build: add codeql to main pushes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,8 @@
 name: "CodeQL"
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
I was hoping that the results would pop up in the Security tab by default but it doesn't since it only checks the branches of the PRs. And apparently, it will fail every PR because it can't find the initial results of the base branch (main) which is not something we want.

So this should solve all of that.