### PR TITLE
bump to js-beautify 1.14.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "cli-color": "^2.0.1",
     "fs-extra": "^9.1.0",
-    "js-beautify": "^1.14.0",
+    "js-beautify": "^1.14.3",
     "lodash": "^4.17.21",
     "resolve": "^1.20.0",
     "umzug": "^2.3.0",


### PR DESCRIPTION
js-beautify 1.14.0 version is vulnerable to Regular Expression Denial of Service (ReDoS) due to an unsafe regex in tokenizer.py and tokenizer.js.

<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
