### PR TITLE
feat: add support for test files colocated with models

### DIFF
--- a/src/assets/models/index.js
+++ b/src/assets/models/index.js
@@ -19,7 +19,12 @@ if (config.use_env_variable) {
 fs
   .readdirSync(__dirname)
   .filter(file => {
-    return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+    return (
+      file.indexOf('.') !== 0 &&
+      file !== basename &&
+      file.slice(-3) === '.js' &&
+      file.indexOf('.test.js') === -1
+    );
   })
   .forEach(file => {
     const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

The models/index.js file is an auto-generated file used to automatically register all models from the models folder
It works under the assumption that the only files you have in your /models folder are models.
This works for most of the cases, but it causes an issue for projects using tests colocated with the tested file, e.g.
```
models/
    person.js
    person.test.js
    dog.js
    dog.test.js
    index.js
```
for such cases, if you want to add unit tests, you would have to either move to a symmetric /tests folder that replicates the structure of your project (for example as this project does), or follow this approach only for the models folder (quite inconsistent), or not write tests for models (quite bad)

This PR addresses the issue by adding a condition that will skip filenames containing `.test.js`.