### PR TITLE
fix: only show error detail when error.original is defined

### DIFF
--- a/src/helpers/view-helper.js
+++ b/src/helpers/view-helper.js
@@ -37,7 +37,7 @@ module.exports = {
 
     this.log();
     console.error(`${clc.red('ERROR:')} ${message}`);
-    if (error.original.detail) {
+    if (error.original?.detail) {
       console.error(`${clc.red('ERROR DETAIL:')} ${error.original.detail}`);
     }
 

--- a/src/helpers/view-helper.js
+++ b/src/helpers/view-helper.js
@@ -37,7 +37,7 @@ module.exports = {
 
     this.log();
     console.error(`${clc.red('ERROR:')} ${message}`);
-    if (error.original?.detail) {
+    if (error.original && error.original.detail) {
       console.error(`${clc.red('ERROR DETAIL:')} ${error.original.detail}`);
     }
 


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Using `"sequelize-cli": "6.5.2",`

When `up` handler of a migration throws a custom error.
```js
throw new Error(
  `foobar`,
);
```

The cli throws the following error
```bash
TypeError: Cannot read properties of undefined (reading 'detail')
    at Object.error (/myproject/node_modules/sequelize-cli/lib/helpers/view-helper.js:31:24)
    at /myproject/node_modules/sequelize-cli/lib/commands/migrate.js:68:39
    at async exports.handler (/myproject/node_modules/sequelize-cli/lib/commands/migrate.js:27:7)
```

The error originates from this line:
```js
    if (error.original.detail) { // this causes the error because original is null/undefined
      console.error(`${_cliColor.default.red('ERROR DETAIL:')} ${error.original.detail}`);
    }
```

In this PR we change the IF condition to check if the original field is set so the error will not occur.