### PR TITLE
include .cts files when discovering migrations

### DIFF
--- a/src/core/migrator.js
+++ b/src/core/migrator.js
@@ -46,7 +46,7 @@ export async function getMigrator(type, args) {
     migrations: {
       params: [sequelize.getQueryInterface(), Sequelize],
       path: helpers.path.getPath(type),
-      pattern: /^(?!.*\.d\.ts$).*\.(cjs|js|ts)$/,
+      pattern: /^(?!.*\.d\.ts$).*\.(cjs|js|cts|ts)$/,
     },
   });
 


### PR DESCRIPTION
The migrator currently uses `/^(?!.*\.d\.ts$).*\.(cjs|js|ts)$/` to look for migration files. This regex does not include `.cts` files, which are [TypeScripts version of `.cjs` files](https://www.typescriptlang.org/docs/handbook/esm-node.html#new-file-extensions).
Since `.ts` and `.cjs` files are already supported, the migrator can include `.cts` files without further changes.