### PR TITLE
feat: allow db:drop with force for PostgreSQL > v13

### DIFF
--- a/test/db/db-drop.test.js
+++ b/test/db/db-drop.test.js
@@ -48,6 +48,30 @@ describe(Support.getTestDialectTeaser('db:drop'), () => {
         }
       );
     });
+    it('correctly drops database with force', function (done) {
+      const databaseName = `my_test_db_${_.random(10000, 99999)}`;
+      prepare(
+        'db:drop --force',
+        () => {
+          this.sequelize
+            .query(
+              `SELECT 1 as exists FROM pg_database WHERE datname = '${databaseName}';`,
+              {
+                type: this.sequelize.QueryTypes.SELECT,
+              }
+            )
+            .then((result) => {
+              expect(result).to.be.empty;
+              done();
+            });
+        },
+        {
+          config: {
+            database: databaseName,
+          },
+        }
+      );
+    });
   }
 
   if (Support.dialectIsMySQL()) {


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This pull request adds a new --force option to the Sequelize CLI for the` db:drop `command, enabling forced dropping of PostgreSQL databases on server versions higher than 13. [See manual](https://www.postgresql.org/docs/current/sql-dropdatabase.html)

**Motivation:**
Currently, the Sequelize CLI lacks the option to force-drop databases on PostgreSQL versions greater than 13. In some scenarios, such as automated testing environments or CI/CD pipelines, it's necessary to forcibly drop databases without prompting for confirmation, especially when the PostgreSQL server version is 13 or above.

**Changes Made:**
- Added a new --force option to the `db:drop` command in the Sequelize CLI.
- Modified the logic to add the `WITH(FORCE)` extra arguments to the SQL with a fallback to normal drop query .
- When the `--force` option is passed and the dialect is PostgreSQL, the CLI now executes the `DROP DATABASE` statement with the `FORCE` option, allowing the database to be forcibly dropped without confirmation.
- Updated the cli docs with usage of flag

**Testing:**
- Added unit test to ensure that the `--force` option behaves as expected on different PostgreSQL server versions.
- Manually tested the CLI with various PostgreSQL server versions to validate the behaviour of the `--force` option.
- This enhancement provides users with a convenient and safe way to force-drop databases when working with PostgreSQL servers on version 13 or higher, improving the overall usability and flexibility of the Sequelize CLI.
