### PR TITLE
refactor: switch cli-color to ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "types.d.ts"
   ],
   "dependencies": {
-    "cli-color": "^2.0.3",
+    "ansis": "^3.2.0",
     "fs-extra": "^9.1.0",
     "js-beautify": "1.14.9",
     "lodash": "^4.17.21",

--- a/src/commands/database.js
+++ b/src/commands/database.js
@@ -4,7 +4,7 @@ import { logMigrator } from '../core/migrator';
 
 import helpers from '../helpers';
 import { cloneDeep, defaults, pick } from 'lodash';
-import clc from 'cli-color';
+import { blueBright } from 'ansis';
 
 const Sequelize = helpers.generic.getSequelize();
 
@@ -61,7 +61,7 @@ exports.handler = async function (args) {
         })
         .catch((e) => helpers.view.error(e));
 
-      helpers.view.log('Database', clc.blueBright(config.database), 'created.');
+      helpers.view.log('Database', blueBright(config.database), 'created.');
 
       break;
     case 'db:drop':
@@ -76,7 +76,7 @@ exports.handler = async function (args) {
         )
         .catch((e) => helpers.view.error(e));
 
-      helpers.view.log('Database', clc.blueBright(config.database), 'dropped.');
+      helpers.view.log('Database', blueBright(config.database), 'dropped.');
 
       break;
   }

--- a/src/commands/migration_generate.js
+++ b/src/commands/migration_generate.js
@@ -3,7 +3,7 @@ import { _baseOptions, _underscoreOption } from '../core/yargs';
 
 import helpers from '../helpers';
 import fs from 'fs';
-import clc from 'cli-color';
+import { blueBright } from 'ansis';
 
 exports.builder = (yargs) =>
   _underscoreOption(
@@ -30,7 +30,7 @@ exports.handler = function (args) {
 
   helpers.view.log(
     'New migration was created at',
-    clc.blueBright(helpers.path.getMigrationPath(args.name)),
+    blueBright(helpers.path.getMigrationPath(args.name)),
     '.'
   );
 

--- a/src/commands/model_generate.js
+++ b/src/commands/model_generate.js
@@ -2,7 +2,7 @@ import process from 'process';
 import { _baseOptions, _underscoreOption } from '../core/yargs';
 
 import helpers from '../helpers';
-import clc from 'cli-color';
+import { blueBright } from 'ansis';
 
 exports.builder = (yargs) =>
   _underscoreOption(
@@ -38,12 +38,12 @@ exports.handler = function (args) {
   helpers.migration.generateTableCreationFile(args);
   helpers.view.log(
     'New model was created at',
-    clc.blueBright(helpers.path.getModelPath(args.name)),
+    blueBright(helpers.path.getModelPath(args.name)),
     '.'
   );
   helpers.view.log(
     'New migration was created at',
-    clc.blueBright(
+    blueBright(
       helpers.path.getMigrationPath(
         helpers.migration.generateMigrationName(args)
       )
@@ -60,7 +60,7 @@ function ensureModelsFolder() {
       'Unable to find models path (' +
         helpers.path.getModelsPath() +
         '). Did you run ' +
-        clc.blueBright('sequelize init') +
+        blueBright`sequelize init` +
         '?'
     );
   }
@@ -72,7 +72,7 @@ function ensureMigrationsFolder() {
       'Unable to find migrations path (' +
         helpers.path.getPath('migration') +
         '). Did you run ' +
-        clc.blueBright('sequelize init') +
+        blueBright`sequelize init` +
         '?'
     );
   }

--- a/src/commands/seed_generate.js
+++ b/src/commands/seed_generate.js
@@ -3,7 +3,7 @@ import { _baseOptions } from '../core/yargs';
 
 import helpers from '../helpers';
 import fs from 'fs';
-import clc from 'cli-color';
+import { blueBright } from 'ansis';
 
 exports.builder = (yargs) =>
   _baseOptions(yargs).option('name', {
@@ -28,7 +28,7 @@ exports.handler = function (args) {
 
   helpers.view.log(
     'New seed was created at',
-    clc.blueBright(helpers.path.getSeederPath(args.name)),
+    blueBright(helpers.path.getSeederPath(args.name)),
     '.'
   );
 

--- a/src/helpers/view-helper.js
+++ b/src/helpers/view-helper.js
@@ -1,4 +1,4 @@
-import clc from 'cli-color';
+import { blueBright, red, underline, yellow } from 'ansis';
 import _ from 'lodash';
 import helpers from './index';
 import getYArgs from '../core/yargs';
@@ -15,7 +15,7 @@ module.exports = {
     ];
 
     this.log();
-    this.log(clc.underline('Sequelize CLI [' + versions.join(', ') + ']'));
+    this.log(underline('Sequelize CLI [' + versions.join(', ') + ']'));
     this.log();
   },
 
@@ -36,13 +36,13 @@ module.exports = {
     }
 
     this.log();
-    console.error(`${clc.red('ERROR:')} ${message}`);
+    console.error(`${red`ERROR:`} ${message}`);
     if (error.original && error.original.detail) {
-      console.error(`${clc.red('ERROR DETAIL:')} ${error.original.detail}`);
+      console.error(`${red`ERROR DETAIL:`} ${error.original.detail}`);
     }
 
     extraMessages.forEach((message) =>
-      console.error(`${clc.red('EXTRA MESSAGE:')} ${message}`)
+      console.error(`${red`EXTRA MESSAGE:`} ${message}`)
     );
     this.log();
 
@@ -50,13 +50,13 @@ module.exports = {
   },
 
   warn(message) {
-    this.log(`${clc.yellow('WARNING:')} ${message}`);
+    this.log(`${yellow`WARNING:`} ${message}`);
   },
 
   notifyAboutExistingFile(file) {
     this.error(
       'The file ' +
-        clc.blueBright(file) +
+        blueBright(file) +
         ' already exists. ' +
         'Run command with --force to overwrite it.'
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1416,6 +1416,11 @@ ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
   integrity sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==
 
+ansis@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansis/-/ansis-3.2.0.tgz#0e050c5be94784f32ffdac4b84fccba064aeae4b"
+  integrity sha512-Yk3BkHH9U7oPyCN3gL5Tc7CpahG/+UFv/6UG03C311Vy9lzRmA5uoxDTpU9CO3rGHL6KzJz/pdDeXZCZ5Mu/Sg==
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -1932,17 +1937,6 @@ clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
-
-cli-color@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-2.0.4.tgz#d658080290968816b322248b7306fad2346fb2c8"
-  integrity sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.64"
-    es6-iterator "^2.0.3"
-    memoizee "^0.4.15"
-    timers-ext "^0.1.7"
 
 cli-cursor@^4.0.0:
   version "4.0.0"
@@ -2478,7 +2472,7 @@ es-errors@^1.3.0:
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.53, es5-ext@^0.10.62, es5-ext@^0.10.64, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
+es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.62, es5-ext@^0.10.64, es5-ext@~0.10.14:
   version "0.10.64"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.64.tgz#12e4ffb48f1ba2ea777f1fcdd1918ef73ea21714"
   integrity sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==
@@ -2505,7 +2499,7 @@ es6-symbol@^3.1.1, es6-symbol@^3.1.3:
     d "^1.0.2"
     ext "^1.7.0"
 
-es6-weak-map@^2.0.1, es6-weak-map@^2.0.3:
+es6-weak-map@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
   integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
@@ -3697,11 +3691,6 @@ is-plain-object@^5.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
-is-promise@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
-  integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
-
 is-property@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
@@ -4140,13 +4129,6 @@ lru-cache@^7.14.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
-lru-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
-  integrity sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==
-  dependencies:
-    es5-ext "~0.10.2"
-
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -4215,20 +4197,6 @@ matchdep@^2.0.0:
     micromatch "^3.0.4"
     resolve "^1.4.0"
     stack-trace "0.0.10"
-
-memoizee@^0.4.15:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
-  integrity sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.53"
-    es6-weak-map "^2.0.3"
-    event-emitter "^0.3.5"
-    is-promise "^2.2.2"
-    lru-queue "^0.1.0"
-    next-tick "^1.1.0"
-    timers-ext "^0.1.7"
 
 meow@^12.0.1:
   version "12.1.1"
@@ -4548,7 +4516,7 @@ negotiator@^0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-next-tick@1, next-tick@^1.1.0:
+next-tick@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
@@ -6091,14 +6059,6 @@ time-stamp@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
   integrity sha512-gLCeArryy2yNTRzTGKbZbloctj64jkZ57hj5zdraXue6aFgd6PmvVtEyiUU+hvU0v7q08oVv8r8ev0tRo6bvgw==
-
-timers-ext@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.7.tgz#6f57ad8578e07a3fb9f91d9387d65647555e25c6"
-  integrity sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==
-  dependencies:
-    es5-ext "~0.10.46"
-    next-tick "1"
 
 to-absolute-glob@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x ] Does `npm run test` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Hello @WikiRik,

I'm the author of the [ansis](https://github.com/webdiscus/ansis)  which you already [know](https://github.com/sequelize/sequelize/pull/17351).

This PR switch the [cli-color](https://github.com/medikoo/cli-color) to [ansis](https://github.com/webdiscus/ansis) package, because:

- the [@sequelize/core](https://github.com/sequelize/sequelize/blob/main/packages/core/package.json) already use the `ansis`
- ansis has `zero` dependencies, `cli-color` has [5 depenedencies](https://www.npmjs.com/package/cli-color?activeTab=dependencies)
- ansis is smaller and [faster](https://github.com/webdiscus/ansis#benchmark) than `cli-color`, see the [features comparison](https://github.com/webdiscus/ansis#compare) and [benchmarks](https://github.com/webdiscus/ansis#benchmark)
   - `ansis` [minified bundle size](https://bundlephobia.com/package/ansis@3.2.0) - `3.5 KB`
   - `cli-color` [minified bundle size](https://bundlephobia.com/package/cli-color@2.0.4) - `49.5 KB`
- ansis supports both `CommonJS` and `ESM`
- ansis supports `Bun`, `Deno`, `Next.JS` runtimes
- ansis supports the CLI params: `NO_COLOR`, `FORCE_COLOR`, `--no-color`, `--color`, the `cli-color` supports `NO_COLOR` only
- ansis supports [named import](https://github.com/webdiscus/ansis#named-import) `import ansis, { red, bold, underline } from 'ansis'` and [nested template strings](https://github.com/webdiscus/ansis#nested-syntax), so your can use color names for clean code, e.g.:
   ```js
    console.error(`${clc.red('ERROR:')} ${message}`); // using cli-color
    console.error(`${red`ERROR:`} ${message}`); // using ansis
   ```
- other packages already trust ansis and uses `ansis`, for example:
   - [@sequelize/core](https://github.com/sequelize/sequelize/blob/main/packages/core/package.json)
   - [facebook/stylex](https://github.com/facebook/stylex/blob/main/packages/cli/package.json)
   - [oclif/core](https://github.com/oclif/core/blob/prerelease/beta/package.json)
   - [grafana/faro-javascript-bundler-plugins](https://github.com/grafana/faro-javascript-bundler-plugins/blob/main/packages/faro-bundlers-shared/package.json)
   - and [thousands others](https://github.com/webdiscus/ansis/network/dependents)
- ansis is optimised for: performance, small-size, must-have features
- quick response to issues
- long term support


![Screenshot 2024-06-07 at 11 43 33](https://github.com/sequelize/cli/assets/6752572/352c9fbf-4608-4d9c-9d33-0f54870f7a2c)
![Screenshot 2024-06-07 at 11 44 03](https://github.com/sequelize/cli/assets/6752572/ed5ad39a-33ef-4d0b-b35e-9fc092350acf)
