### PR TITLE
fix: add support for the paranoid flag

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,13 +11,33 @@ You may skip the template below, if
 
 _Please make sure to review and check all of these items:_
 
-- [ ] Does `npm run test` pass with this change (including linting)?
-- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
-- [ ] Have you added new tests to prevent regressions?
-- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
+- [x] Does `npm run test` pass with this change (including linting)?
+- [x] Does the description below contain a link to an existing issue (Closes #1139) or a description of the issue you are solving?
+- [x] Have you added new tests to prevent regressions?
+- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
 
 <!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->
 
 ### Description of change
+The following files have been changed:
+>model_generate.js
+>yargs.js
+>model.js
+>model-helper.js
+>migration-helper.js
+>create-table.js
+>create.test.js
 
-<!-- Please provide a description of the change here. -->
+solved issue: 
+>https://github.com/sequelize/cli/issues/1139
+
+The following test has been adapted: 
+>model/create.test.js
+
+update to the documentation: 
+
+>In order to be able to assign the paranoid flag via the CLI, it is possible to set the flag ```--paranoid true``` after the ```model:generate``` 
+
+>You can also set the paranoid flag to true in the ```.sequelizerc``` , so all created models and migrations will be paranoid by default. 
+
+>If you have set paranoid to true in the config, you can set paranoid to false for individual tables by setting the flag to ```--paranoid false``` via the CLI after the ```model:generate```

--- a/src/assets/migrations/create-table.js
+++ b/src/assets/migrations/create-table.js
@@ -25,7 +25,14 @@ module.exports = {
       <%= updatedAt %>: {
         allowNull: false,
         type: Sequelize.DATE
-      }
+      },
+
+      <% if (paranoid) { %>
+      deletedAt: {
+        type: Sequelize.DATE,
+        allowNull: true
+      },
+      <% } %>
     });
   },
 

--- a/src/assets/models/model.js
+++ b/src/assets/models/model.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
      * This method is not a part of Sequelize lifecycle.
      * The `models/index` file will call this method automatically.
      */
-    static associate (models) {
+    static associate(models) {
       // define association here
     }
   }
@@ -23,6 +23,8 @@ module.exports = (sequelize, DataTypes) => {
     sequelize,
     modelName: '<%= name %>',
     <%= underscored ? 'underscored: true,' : '' %>
+    paranoid: <%= paranoid %>,  
+    timestamps: true
   });
 
   return <%= name %>;

--- a/src/commands/model_generate.js
+++ b/src/commands/model_generate.js
@@ -1,8 +1,8 @@
 import process from 'process';
 import { _baseOptions, _underscoreOption } from '../core/yargs';
-
 import helpers from '../helpers';
 import clc from 'cli-color';
+import getYArgs from '../core/yargs';
 
 exports.builder = (yargs) =>
   _underscoreOption(
@@ -21,6 +21,17 @@ exports.builder = (yargs) =>
         describe: 'Forcefully re-creates model with the same name',
         type: 'string',
         demandOption: false,
+      })
+      .option('paranoid', {
+        describe: 'Enable paranoid mode for soft deletes',
+        type: 'boolean',
+        demandOption: false,
+        default: getYArgs().argv.paranoid,
+      })
+      .option('underscored', {
+        describe: "Use snake case for the timestamp's attribute names",
+        type: 'boolean',
+        default: false,
       })
   ).argv;
 

--- a/src/core/yargs.js
+++ b/src/core/yargs.js
@@ -59,6 +59,16 @@ export function _baseOptions(yargs) {
       describe: 'When available show various debug information',
       default: false,
       type: 'boolean',
+    })
+    .option('paranoid', {
+      describe: 'Enable paranoid mode for soft deletes',
+      default: false,
+      type: 'boolean',
+    })
+    .option('underscored', {
+      describe: "Use snake case for the timestamp's attribute names",
+      default: false,
+      type: 'boolean',
     });
 }
 

--- a/src/helpers/migration-helper.js
+++ b/src/helpers/migration-helper.js
@@ -14,6 +14,8 @@ module.exports = {
       attributes: helpers.model.transformAttributes(args.attributes),
       createdAt: args.underscored ? 'created_at' : 'createdAt',
       updatedAt: args.underscored ? 'updated_at' : 'updatedAt',
+      paranoid: args.paranoid,
+      underscored: args.underscored,
     });
   },
 

--- a/src/helpers/model-helper.js
+++ b/src/helpers/model-helper.js
@@ -112,6 +112,7 @@ module.exports = {
       name: args.name,
       attributes: this.transformAttributes(args.attributes),
       underscored: args.underscored,
+      paranoid: args.paranoid,
     });
   },
 

--- a/test/model/create.test.js
+++ b/test/model/create.test.js
@@ -282,8 +282,8 @@ const _ = require('lodash');
                   };
 
                   const targetContent = attrUnd.underscored
-                    ? "modelName: 'User',\n    underscored: true,\n  });"
-                    : "modelName: 'User',\n  });";
+                    ? "modelName: 'User',\n    underscored: true,\n    paranoid: false,\n    timestamps: true\n  });"
+                    : "modelName: 'User',\n    paranoid: false,\n    timestamps: true\n  });";
 
                   if (attrUnd.underscored) {
                     flags.underscored = attrUnd.underscored;


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #1139) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
The following files have been changed:
>model_generate.js
>yargs.js
>model.js
>model-helper.js
>migration-helper.js
>create-table.js
>create.test.js

solved issue: 
>https://github.com/sequelize/cli/issues/1139

The following test has been adapted: 
>model/create.test.js

update to the documentation: 

>In order to be able to assign the paranoid flag via the CLI, it is possible to set the flag ```--paranoid true``` after the ```model:generate``` 

>You can also set the paranoid flag to true in the ```.sequelizerc``` , so all created models and migrations will be paranoid by default. 

>If you have set paranoid to true in the config, you can set paranoid to false for individual tables by setting the flag to ```--paranoid false``` via the CLI after the ```model:generate```