### PR TITLE
fix: replace fs.R_OK with fs.constants.R_OK

### DIFF
--- a/src/helpers/path-helper.js
+++ b/src/helpers/path-helper.js
@@ -97,7 +97,7 @@ module.exports = {
   existsSync(pathToCheck) {
     if (fs.accessSync) {
       try {
-        fs.accessSync(pathToCheck, fs.R_OK);
+        fs.accessSync(pathToCheck, fs.constants.R_OK);
         return true;
       } catch (e) {
         return false;


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

### Description of change

- Replace `fs.R_OK` with `fs.constants.R_OK` since it got deprecated in node 24

### References

- https://nodejs.org/en/blog/release/v24.0.0
	- [b02cd411c2](https://github.com/nodejs/node/commit/b02cd411c2) - (SEMVER-MAJOR) fs: runtime deprecate fs.F_OK, fs.R_OK, fs.W_OK, fs.X_OK (Livia Medeiros) [#49686](https://github.com/nodejs/node/pull/49686)
- https://github.com/nodejs/node/pull/49683
