### PR TITLE
feat: skip-execution flag for migrate command

### DIFF
--- a/src/commands/migrate.js
+++ b/src/commands/migrate.js
@@ -24,6 +24,11 @@ exports.builder = (yargs) =>
         'Migration name. When specified, only this migration will be run. Mutually exclusive with --to and --from',
       type: 'string',
       conflicts: ['to', 'from'],
+    })
+    .option('skip-execution', {
+      describe: 'Mark migration as completed without actually executing it',
+      default: false,
+      type: 'boolean',
     }).argv;
 
 exports.handler = async function (args) {
@@ -85,9 +90,53 @@ function migrate(args) {
             }
             options.from = args.from;
           }
+          if (args['skip-execution']) {
+            let migrationsToRun = migrations;
+
+            if (args.name) {
+              migrationsToRun = [args.name];
+            } else {
+              if (options.from) {
+                const fromIndex = migrations.findIndex(
+                  (m) => m.file === options.from
+                );
+                if (fromIndex !== -1) {
+                  migrationsToRun = migrations.slice(fromIndex + 1);
+                }
+              }
+              if (options.to) {
+                const toIndex = migrationsToRun.findIndex(
+                  (m) => m.file === options.to
+                );
+                if (toIndex !== -1) {
+                  migrationsToRun = migrationsToRun.slice(0, toIndex + 1);
+                }
+              }
+            }
+
+            if (migrationsToRun.length === 0) {
+              helpers.view.log('No migrations to skip.');
+              process.exit(0);
+            }
+
+            return Promise.all(
+              migrationsToRun.map((migration) => {
+                helpers.view.log(
+                  'Marking migration as executed:',
+                  migration.file
+                );
+                return migrator.storage.logMigration(migration.file);
+              })
+            ).then(() => {
+              return { executed: true };
+            });
+          }
+
           return options;
         })
         .then((options) => {
+          if (options && options.executed) return;
+
           if (args.name) {
             return migrator.up(args.name);
           } else {

--- a/test/db/migrate-skip.test.js
+++ b/test/db/migrate-skip.test.js
@@ -1,0 +1,64 @@
+const expect = require('expect.js');
+const Support = require(__dirname + '/../support');
+const helpers = require(__dirname + '/../support/helpers');
+const gulp = require('gulp');
+
+describe(Support.getTestDialectTeaser('db:migrate --skip-execution'), () => {
+  const prepare = function (callback) {
+    const config = { url: helpers.getTestUrl() };
+    const configContent = 'module.exports = ' + JSON.stringify(config);
+    let result = '';
+
+    return gulp
+      .src(Support.resolveSupportPath('tmp'))
+      .pipe(helpers.clearDirectory())
+      .pipe(helpers.runCli('init'))
+      .pipe(helpers.removeFile('config/config.json'))
+      .pipe(helpers.copyMigration('createPerson.js'))
+      .pipe(helpers.overwriteFile(configContent, 'config/config.js'))
+      .pipe(helpers.runCli('db:migrate --skip-execution', { pipeStdout: true }))
+      .on('error', (e) => {
+        callback(e);
+      })
+      .on('data', (data) => {
+        result += data.toString();
+      })
+      .on('end', () => {
+        callback(null, result);
+      });
+  };
+
+  beforeEach(function () {
+    const queryInterface = this.sequelize.getQueryInterface();
+    this.queryGenerator =
+      queryInterface.queryGenerator || queryInterface.QueryGenerator;
+  });
+
+  it('marks migration as executed but does not execute it', function (done) {
+    prepare((err, output) => {
+      if (err) return done(err);
+
+      helpers.readTables(this.sequelize, (tables) => {
+        expect(tables).to.have.length(1);
+        expect(tables).to.contain('SequelizeMeta');
+        expect(tables).to.not.contain('Person');
+
+        helpers
+          .execQuery(
+            this.sequelize,
+            this.queryGenerator.selectQuery('SequelizeMeta'),
+            { raw: true, type: 'SELECT' }
+          )
+          .then((items) => {
+            expect(items.length).to.equal(1);
+            expect(items[0].name).to.contain('createPerson');
+
+            expect(output).to.contain('Marking migration as executed');
+
+            done();
+          })
+          .catch((e) => done(e));
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? [https://github.com/sequelize/website/pull/825](https://github.com/sequelize/website/pull/825)

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

## Skipping Migration Execution

In some cases you may want to mark migrations as completed without actually executing their SQL. This can be useful when:
	- The database schema was applied manually
	- You are syncing migration history between environments
	- You are adopting Sequelize CLI for an existing database
	- You want to avoid re-running destructive or already-applied changes

For this purpose, I have implemented a custom `--skip-execution` flag.