### PR TITLE
build(deps): replace fs-extra with native node:fs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,9 @@
   "packages": {
     "": {
       "name": "sequelize-cli",
-      "version": "6.3.0",
+      "version": "6.6.3",
       "license": "MIT",
       "dependencies": {
-        "fs-extra": "^9.1.0",
         "js-beautify": "1.15.4",
         "lodash": "^4.17.21",
         "picocolors": "^1.1.1",
@@ -125,6 +124,7 @@
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2558,6 +2558,7 @@
       "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2591,6 +2592,7 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3049,15 +3051,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -3320,6 +3313,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4045,6 +4039,7 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4665,6 +4660,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -5484,21 +5480,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -6173,6 +6154,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/growl": {
@@ -7389,18 +7371,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonparse": {
@@ -9480,6 +9450,7 @@
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9834,6 +9805,7 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -11943,15 +11915,6 @@
       "dependencies": {
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "through2-filter": "3.0.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/unset-value": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "types.d.ts"
   ],
   "dependencies": {
-    "fs-extra": "^9.1.0",
     "js-beautify": "1.15.4",
     "lodash": "^4.17.21",
     "picocolors": "^1.1.1",

--- a/src/helpers/asset-helper.js
+++ b/src/helpers/asset-helper.js
@@ -1,9 +1,22 @@
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
+
+function copyRecursiveSync(src, dest) {
+  const stat = fs.statSync(src);
+
+  if (stat.isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true });
+    for (const child of fs.readdirSync(src)) {
+      copyRecursiveSync(path.join(src, child), path.join(dest, child));
+    }
+  } else {
+    fs.copyFileSync(src, dest);
+  }
+}
 
 const assets = {
   copy: (from, to) => {
-    fs.copySync(path.resolve(__dirname, '..', 'assets', from), to);
+    copyRecursiveSync(path.resolve(__dirname, '..', 'assets', from), to);
   },
 
   read: (assetPath) => {
@@ -26,7 +39,7 @@ const assets = {
   },
 
   mkdirp: (pathToCreate) => {
-    fs.mkdirpSync(pathToCreate);
+    fs.mkdirSync(pathToCreate, { recursive: true });
   },
 };
 

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -6,7 +6,7 @@ var support = require('./index');
 var through = require('through2');
 var expect = require('expect.js');
 var path = require('path');
-var fs = require('fs-extra');
+var fs = require('fs');
 
 module.exports = {
   getTestConfig: function (mixin) {
@@ -95,7 +95,7 @@ module.exports = {
 
   copyFile: function (from, to) {
     return through.obj(function (file, encoding, callback) {
-      fs.copy(from, path.resolve(file.path, to), function (err) {
+      fs.copyFile(from, path.resolve(file.path, to), function (err) {
         callback(err, file);
       });
     });
@@ -235,6 +235,6 @@ function logToFile(thing) {
   var logPath = __dirname + '/../../logs';
   var logFile = logPath + '/test.log';
 
-  fs.mkdirpSync(logPath);
+  fs.mkdirSync(logPath, { recursive: true });
   fs.appendFileSync(logFile, '[' + new Date() + '] ' + text + '\n');
 }


### PR DESCRIPTION
## Summary
- Replace `fs-extra` dependency with native `node:fs` equivalents
- All replacement APIs are available in Node.js 10+, matching the project's minimum engine requirement
- Removes `fs-extra` and its transitive dependencies (`at-least-node`, `jsonfile`, `universalify`) from the dependency tree

## Changes
- `src/helpers/asset-helper.js` — Replace `fs-extra` import with `fs`; `copySync` with a recursive copy helper using `fs.copyFileSync`/`fs.readdirSync`/`fs.mkdirSync`; `mkdirpSync` with `fs.mkdirSync({ recursive: true })`
- `test/support/helpers.js` — Replace `fs-extra` import with `fs`; `copy` with `fs.copyFile`; `mkdirpSync` with `fs.mkdirSync({ recursive: true })`
- `package.json` — Remove `fs-extra` from dependencies
- `package-lock.json` — Regenerated without `fs-extra` and its transitive deps

## Testing
- `npm run lint` passes
- `npm run build` passes
- All 326 tests pass (1 pre-existing failure in `model:create` with complex enum attributes, unrelated to this change)

Part of the [e18e ecosystem cleanup](https://github.com/e18e/ecosystem-issues/issues/33) initiative.