### PR TITLE
fix(init): use JS template for dynamic configuration

### DIFF
--- a/src/assets/config/dynamic-config.js
+++ b/src/assets/config/dynamic-config.js
@@ -1,0 +1,26 @@
+// load .env variables
+require('dotenv').config(); // assuming .env is in the current directory
+
+module.exports = {
+  development: {
+    username: process.env.DB_USER || 'root',
+    password: process.env.DB_PASS || null,
+    database: process.env.DEV_DB_NAME || 'database_development',
+    host: process.env.DB_HOST || '127.0.0.1',
+    dialect: 'mysql',
+  },
+  test: {
+    username: process.env.DB_USER || 'root',
+    password: process.env.DB_PASS || null,
+    database: process.env.TEST_DB_NAME || 'database_test',
+    host: process.env.DB_HOST || '127.0.0.1',
+    dialect: 'mysql',
+  },
+  production: {
+    username: process.env.DB_USER || 'root',
+    password: process.env.DB_PASS || null,
+    database: process.env.PROD_DB_NAME || 'database_production',
+    host: process.env.DB_HOST || '127.0.0.1',
+    dialect: 'mysql',
+  },
+};

--- a/src/helpers/config-helper.js
+++ b/src/helpers/config-helper.js
@@ -63,46 +63,51 @@ const api = {
     return helpers.path.existsSync(api.getConfigFile());
   },
 
-  getDefaultConfig() {
-    return (
-      JSON.stringify(
-        {
-          development: {
-            username: 'root',
-            password: null,
-            database: 'database_development',
-            host: '127.0.0.1',
-            dialect: 'mysql',
+  getDefaultConfig(configPath) {
+    if (configPath.endsWith('js')) {
+      return helpers.asset.read('config/dynamic-config.js');
+    } else {
+      return (
+        JSON.stringify(
+          {
+            development: {
+              username: 'root',
+              password: null,
+              database: 'database_development',
+              host: '127.0.0.1',
+              dialect: 'mysql',
+            },
+            test: {
+              username: 'root',
+              password: null,
+              database: 'database_test',
+              host: '127.0.0.1',
+              dialect: 'mysql',
+            },
+            production: {
+              username: 'root',
+              password: null,
+              database: 'database_production',
+              host: '127.0.0.1',
+              dialect: 'mysql',
+            },
           },
-          test: {
-            username: 'root',
-            password: null,
-            database: 'database_test',
-            host: '127.0.0.1',
-            dialect: 'mysql',
-          },
-          production: {
-            username: 'root',
-            password: null,
-            database: 'database_production',
-            host: '127.0.0.1',
-            dialect: 'mysql',
-          },
-        },
-        undefined,
-        2
-      ) + '\n'
-    );
+          undefined,
+          2
+        ) + '\n'
+      );
+    }
   },
 
   writeDefaultConfig() {
-    const configPath = path.dirname(api.getConfigFile());
+    const configFilePath = api.getConfigFile();
+    const configFolderPath = path.dirname(configFilePath);
 
-    if (!helpers.path.existsSync(configPath)) {
-      helpers.asset.mkdirp(configPath);
+    if (!helpers.path.existsSync(configFolderPath)) {
+      helpers.asset.mkdirp(configFolderPath);
     }
 
-    fs.writeFileSync(api.getConfigFile(), api.getDefaultConfig());
+    fs.writeFileSync(configFilePath, api.getDefaultConfig(configFilePath));
   },
 
   readConfig() {

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -126,6 +126,23 @@ const gulp = require('gulp');
       });
     });
 
+    it('does not put JSON content in dynamic custom configuration file', (done) => {
+      gulp
+        .src(Support.resolveSupportPath('tmp'))
+        .pipe(helpers.clearDirectory())
+        .pipe(helpers.runCli(flag + ' --config config/database.js'))
+        .pipe(
+          helpers.teardown(() => {
+            gulp
+              .src(Support.resolveSupportPath('tmp', 'config'))
+              .pipe(helpers.readFile('database.js'))
+              .pipe(helpers.ensureContent('module.exports'))
+              .pipe(helpers.ensureContent('process.env'))
+              .pipe(helpers.teardown(done));
+          })
+        );
+    });
+
     it('does not overwrite an existing config.json file', (done) => {
       gulp
         .src(Support.resolveSupportPath('tmp'))


### PR DESCRIPTION
<!--
Please fill in the template below.
If unsure about something, just do as best as you're able.

You may skip the template below, if
 - You are only updating documentation
 - You are only fixing minor issue, which does not impact public API
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Closes #1566

When using `.sequelizerc` with a `.js` config path, `sequelize init` 
was generating JSON content inside the `.js` file instead of valid JS.

This fix checks if the config path ends with `.js` and generates 
the correct JS template accordingly.
